### PR TITLE
Add vTaskYieldWithinAPI for taskYIELD_IF_USING_PREEMPTION

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -287,6 +287,20 @@
     #define portSOFTWARE_BARRIER()
 #endif
 
+#ifndef configNUM_CORES
+    #define configNUM_CORES    1
+#endif
+
+#ifndef portGET_CORE_ID
+
+    #if configNUM_CORES == 1
+        #define portGET_CORE_ID()   0
+    #else
+        #error configNUM_CORES is set to more than 1 then portGET_CORE_ID must also be defined.
+    #endif /* configNUM_CORES */
+
+#endif /* portGET_CORE_ID */
+
 /* The timers module relies on xTaskGetSchedulerState(). */
 #if configUSE_TIMERS == 1
 
@@ -1067,7 +1081,6 @@
 #ifndef configRUN_ADDITIONAL_TESTS
     #define configRUN_ADDITIONAL_TESTS    0
 #endif
-
 
 /* Sometimes the FreeRTOSConfig.h settings only allow a task to be created using
  * dynamically allocated RAM, in which case when any task is deleted it is known

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -291,6 +291,12 @@
     #define configNUM_CORES    1
 #endif
 
+#if ( configNUM_CORES > 1 )
+    #if portCRITICAL_NESTING_IN_TCB == 0
+        #error portCRITICAL_NESTING_IN_TCB is required in SMP
+    #endif
+#endif
+
 #ifndef portGET_CORE_ID
 
     #if configNUM_CORES == 1

--- a/include/task.h
+++ b/include/task.h
@@ -3109,6 +3109,11 @@ TaskHandle_t pvTaskIncrementMutexHeldCount( void ) PRIVILEGED_FUNCTION;
  */
 void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNCTION;
 
+/*
+ * For internal use only. Same as portYIELD_WITHIN_API() in single core FreeRTOS.
+ * For SMP this is not defined by the port.
+ */
+void vTaskYieldWithinAPI( void );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/tasks.c
+++ b/tasks.c
@@ -64,7 +64,11 @@
  * performed just because a higher priority task has been woken. */
     #define taskYIELD_IF_USING_PREEMPTION()
 #else
-    #define taskYIELD_IF_USING_PREEMPTION()    vTaskYieldWithinAPI()
+    #if configNUM_CORES == 1
+        #define taskYIELD_IF_USING_PREEMPTION()    portYIELD_WITHIN_API()
+    #else
+        #define taskYIELD_IF_USING_PREEMPTION()    vTaskYieldWithinAPI()
+    #endif
 #endif
 
 /* Values that can be assigned to the ucNotifyState member of the TCB. */
@@ -4363,26 +4367,26 @@ static void prvResetNextTaskUnblockTime( void )
 #endif /* configUSE_MUTEXES */
 /*-----------------------------------------------------------*/
 
+#if ( portCRITICAL_NESTING_IN_TCB == 1 )
+
 /*
  * If not in a critical section then yield immediately.
  * Otherwise set xYieldPendings to true to wait to
  * yield until exiting the critical section.
  */
-void vTaskYieldWithinAPI( void )
-{
-    #if ( portCRITICAL_NESTING_IN_TCB == 1 )
+    void vTaskYieldWithinAPI( void )
+    {
         if( pxCurrentTCB->uxCriticalNesting == 0U )
         {
-            portYIELD_WITHIN_API();
+            portYIELD();
         }
         else
         {
             xYieldPendings[ portGET_CORE_ID() ] = pdTRUE;
         }
-    #else
-        portYIELD_WITHIN_API();
-    #endif
-}
+    }
+
+#endif /* portCRITICAL_NESTING_IN_TCB */
 /*-----------------------------------------------------------*/
 
 #if ( portCRITICAL_NESTING_IN_TCB == 1 )


### PR DESCRIPTION
Add vTaskYieldWithinAPI for taskYIELD_IF_USING_PREEMPTION

Description
-----------
* Add configNUM_CORES config for SMP
* Add portGET_CORE_ID porting config and default return 0 to compatible
  with single core demos
* Replace xYieldPending with xYieldPendings for multiple cores
* Add vTaskYieldWithinAPI function for yield pending if the task is in
  criticial section. This check are enabled only when portCRITICAL_NESTING_IN_TCB
  is enabled
* taskYIELD_IF_USING_PREEMPTION use vTaskYieldWithinAPI when
  configUSE_PREEMPTION is set to 1

The following sections will be updated in other commits
* taskYIELD_IF_USING_PREEMPTION usage in multiple cores
* xYieldPendings usage in multiple cores

Test Steps
-----------
* WIN32-MSVC main full project
* Raspberry pi pico single core main full project

Related Issue
-----------
<!-- If any, please provide issue ID. -->

Performance Comparison Test
-----------
* No performance difference for this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
