### PR TITLE
Add pxCurrentTCBs for multiple cores

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -144,6 +144,10 @@
 
 #else /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
+    #if ( configNUM_CORES > 1 )
+        #error configUSE_PORT_OPTIMISED_TASK_SELECTION not yet supported in SMP
+    #endif
+
 /* If configUSE_PORT_OPTIMISED_TASK_SELECTION is 1 then task selection is
  * performed in a way that is tailored to the particular microcontroller
  * architecture being used. */

--- a/tasks.c
+++ b/tasks.c
@@ -590,8 +590,9 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
 /*-----------------------------------------------------------*/
 
-/* SMP_TODO : Update this function in another commit. */
-#if ( configUSE_PORT_OPTIMISED_TASK_SELECTION == 0 )
+/* SMP_TODO : This is a temporay implementation for compilation.
+ * Update this function in another commit. */
+#if ( configUSE_PORT_OPTIMISED_TASK_SELECTION == 0 ) && ( configNUM_CORES > 1 )
     static BaseType_t prvSelectHighestPriorityTask( void )
     {
         UBaseType_t uxTopPriority = uxTopReadyPriority;
@@ -604,12 +605,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         }
 
         /* listGET_OWNER_OF_NEXT_ENTRY indexes through the list, so the tasks of
-         * the  same priority get an equal share of the processor time. */
-        #if ( configNUM_CORES == 1 )
-            listGET_OWNER_OF_NEXT_ENTRY( pxCurrentTCB, &( pxReadyTasksLists[ uxTopPriority ] ) );
-        #else
-            listGET_OWNER_OF_NEXT_ENTRY( pxCurrentTCBs[ portGET_CORE_ID() ], &( pxReadyTasksLists[ uxTopPriority ] ) );
-        #endif
+         * the same priority get an equal share of the processor time. */
+        listGET_OWNER_OF_NEXT_ENTRY( pxCurrentTCBs[ portGET_CORE_ID() ], &( pxReadyTasksLists[ uxTopPriority ] ) );
         uxTopReadyPriority = uxTopPriority;
     }
 #endif


### PR DESCRIPTION

<!--- Title -->

Description
-----------
* Keep pxCurrentTCB for single core
* Add pxCurrentTCBs for SMP
* Add xTaskGetCurrentTaskHandle for SMP
* Replace taskSELECT_HIGHEST_PRIORITY_TASK with temporary prvSelectHighestPriorityTask

Test Steps
-----------
* Raspberry PI pico main_full
* Windows simulator MSVC

Related Issue
-----------
SMP_TODO
* Update pxCurrentTCBs usage for SMP
* Update prvSelectHighestPriorityTask implementation for SMP
* Update xTaskGetCurrentTaskHandle implementation for SMP

Performance Comparison Test
-----------
* No performance difference for this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
