### PR TITLE
Add SMP critical section functions

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -319,7 +319,7 @@
 
 #ifndef portSET_INTERRUPT_MASK
 
-    #if ( configNUM_CORES == 1 )
+    #if ( configNUM_CORES > 1 )
         #error portSET_INTERRUPT_MASK is required in SMP
     #endif
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -299,13 +299,39 @@
 
 #ifndef portGET_CORE_ID
 
-    #if configNUM_CORES == 1
+    #if ( configNUM_CORES == 1 )
         #define portGET_CORE_ID()   0
     #else
         #error configNUM_CORES is set to more than 1 then portGET_CORE_ID must also be defined.
     #endif /* configNUM_CORES */
 
 #endif /* portGET_CORE_ID */
+
+#ifndef portYIELD_CORE
+
+    #if ( configNUM_CORES == 1 )
+        #define portYIELD_CORE( x )   portYIELD()
+    #else
+        #error configNUM_CORES is set to more than 1 then portYIELD_CORE must also be defined.
+    #endif /* configNUM_CORES */
+
+#endif /* portYIELD_CORE */
+
+#ifndef portSET_INTERRUPT_MASK
+
+    #if ( configNUM_CORES == 1 )
+        #error portSET_INTERRUPT_MASK is required in SMP
+    #endif
+
+#endif  /* portSET_INTERRUPT_MASK */
+
+#ifndef portCLEAR_INTERRUPT_MASK
+
+    #if ( configNUM_CORES > 1 )
+        #error portCLEAR_INTERRUPT_MASK is required in SMP
+    #endif
+
+#endif  /* portCLEAR_INTERRUPT_MASK */
 
 /* The timers module relies on xTaskGetSchedulerState(). */
 #if configUSE_TIMERS == 1

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -333,6 +333,14 @@
 
 #endif  /* portCLEAR_INTERRUPT_MASK */
 
+#ifndef portCHECK_IF_IN_ISR
+
+    #if ( configNUM_CORES > 1 )
+        #error portCHECK_IF_IN_ISR is required in SMP
+    #endif
+
+#endif  /* portCHECK_IF_IN_ISR */
+
 /* The timers module relies on xTaskGetSchedulerState(). */
 #if configUSE_TIMERS == 1
 

--- a/tasks.c
+++ b/tasks.c
@@ -4604,11 +4604,14 @@ static void prvResetNextTaskUnblockTime( void )
             {
                 portASSERT_IF_IN_ISR();
                 #if ( configNUM_CORES > 1 )
-                    /* The only time there would be a problem is if this is called
-                     * before a context switch and vTaskExitCritical() is called
-                     * after pxCurrentTCB changes. Therefore this should not be
-                     * used within vTaskSwitchContext(). */
-                    prvCheckForRunStateChange();
+                    if( uxSchedulerSuspended == 0U )
+                    {
+                        /* The only time there would be a problem is if this is called
+                         * before a context switch and vTaskExitCritical() is called
+                         * after pxCurrentTCB changes. Therefore this should not be
+                         * used within vTaskSwitchContext(). */
+                        prvCheckForRunStateChange();
+                    }
                 #endif
             }
         }

--- a/tasks.c
+++ b/tasks.c
@@ -446,11 +446,13 @@ PRIVILEGED_DATA static volatile UBaseType_t uxSchedulerSuspended = ( UBaseType_t
 
 /* File private functions. --------------------------------*/
 
-/*
- * Checks to see if another task moved the current task out of the ready
- * list while it was waiting to enter a critical section and yields if so.
- */
-static void prvCheckForRunStateChange( void );
+#if ( configNUM_CORES > 1 )
+    /*
+     * Checks to see if another task moved the current task out of the ready
+     * list while it was waiting to enter a critical section and yields if so.
+     */
+    static void prvCheckForRunStateChange( void );
+#endif  /* ( configNUM_CORES > 1 ) */
 
 /*
  * Selects the highest priority available task

--- a/tasks.c
+++ b/tasks.c
@@ -4658,8 +4658,6 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCritical( void )
     {
-        BaseType_t xYieldCurrentTask;
-
         if( xSchedulerRunning != pdFALSE )
         {
             /* If pxCurrentTCB->uxCriticalNesting is zero then this function
@@ -4677,6 +4675,9 @@ static void prvResetNextTaskUnblockTime( void )
                 if( pxCurrentTCB->uxCriticalNesting == 0U )
                 {
                     #if ( configNUM_CORES > 1 )
+                    {
+                        BaseType_t xYieldCurrentTask;
+
                         /* Get the xYieldPending stats inside the critical section. */
                         xYieldCurrentTask = xYieldPendings[ portGET_CORE_ID() ];
 
@@ -4692,8 +4693,11 @@ static void prvResetNextTaskUnblockTime( void )
                         {
                             portYIELD();
                         }
+                    }
                     #else
+                    {
                         portENABLE_INTERRUPTS();
+                    }
                     #endif /* ( configNUM_CORES > 1 ) */
                 }
                 else

--- a/tasks.c
+++ b/tasks.c
@@ -4653,8 +4653,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCritical( void )
     {
-        BaseType_t xCoreID;
-        BaseType_t xYieldForCurrentCore;
+        BaseType_t xYieldCurrentTask;
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -4671,8 +4670,7 @@ static void prvResetNextTaskUnblockTime( void )
                 ( pxCurrentTCB->uxCriticalNesting )--;
 
                 /* Get the xYieldPending stats inside the critical section. */
-                xCoreID = portGET_CORE_ID();
-                xYieldForCurrentCore = xYieldPendings[ xCoreID ];
+                xYieldCurrentTask = xYieldPendings[ portGET_CORE_ID() ];
 
                 #if ( configNUM_CORES > 1 )
                     portRELEASE_ISR_LOCK();
@@ -4684,9 +4682,9 @@ static void prvResetNextTaskUnblockTime( void )
                  * xYieldPending to true. So now that we have exited the
                  * critical section check if xYieldPending is true, and
                  * if so yield. */
-                if( xYieldForCurrentCore != pdFALSE )
+                if( xYieldCurrentTask != pdFALSE )
                 {
-                    portYIELD_CORE( xCoreID );
+                    portYIELD();
                 }
             }
             else
@@ -4707,8 +4705,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
-        BaseType_t xCoreID;
-        BaseType_t xYieldForCurrentCore;
+        BaseType_t xYieldCurrentTask;
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -4725,8 +4722,7 @@ static void prvResetNextTaskUnblockTime( void )
                 ( pxCurrentTCB->uxCriticalNesting )--;
 
                 /* Get the xYieldPending stats inside the critical section. */
-                xCoreID = portGET_CORE_ID();
-                xYieldForCurrentCore = xYieldPendings[ xCoreID ];
+                xYieldCurrentTask = xYieldPendings[ portGET_CORE_ID() ];
 
                 portRELEASE_ISR_LOCK();
                 portCLEAR_INTERRUPT_MASK( uxSavedInterruptStatus );
@@ -4735,9 +4731,9 @@ static void prvResetNextTaskUnblockTime( void )
                  * xYieldPending to true. So now that we have exited the
                  * critical section check if xYieldPending is true, and
                  * if so yield. */
-                if( xYieldForCurrentCore != pdFALSE )
+                if( xYieldCurrentTask != pdFALSE )
                 {
-                    portYIELD_CORE( xCoreID );
+                    portYIELD();
                 }
             }
             else

--- a/tasks.c
+++ b/tasks.c
@@ -4661,30 +4661,39 @@ static void prvResetNextTaskUnblockTime( void )
              * does not match a previous call to vTaskEnterCritical(). */
             configASSERT( pxCurrentTCB->uxCriticalNesting > 0U );
 
-            if( pxCurrentTCB->uxCriticalNesting > 1U )
+            /* This function should not be called in ISR. Use vTaskExitCriticalFromISR
+             * to exit critical section from ISR. */
+            portASSERT_IF_IN_ISR();
+
+            if( pxCurrentTCB->uxCriticalNesting > 0U )
             {
                 ( pxCurrentTCB->uxCriticalNesting )--;
-            }
-            else if( pxCurrentTCB->uxCriticalNesting == 1U )
-            {
-                ( pxCurrentTCB->uxCriticalNesting )--;
 
-                /* Get the xYieldPending stats inside the critical section. */
-                xYieldCurrentTask = xYieldPendings[ portGET_CORE_ID() ];
-
-                #if ( configNUM_CORES > 1 )
-                    portRELEASE_ISR_LOCK();
-                    portRELEASE_TASK_LOCK();
-                #endif
-                portENABLE_INTERRUPTS();
-
-                /* When a task yields in a critical section it just sets
-                 * xYieldPending to true. So now that we have exited the
-                 * critical section check if xYieldPending is true, and
-                 * if so yield. */
-                if( xYieldCurrentTask != pdFALSE )
+                if( pxCurrentTCB->uxCriticalNesting == 0U )
                 {
-                    portYIELD();
+                    #if ( configNUM_CORES > 1 )
+                        /* Get the xYieldPending stats inside the critical section. */
+                        xYieldCurrentTask = xYieldPendings[ portGET_CORE_ID() ];
+
+                        portRELEASE_ISR_LOCK();
+                        portRELEASE_TASK_LOCK();
+                        portENABLE_INTERRUPTS();
+
+                        /* When a task yields in a critical section it just sets
+                         * xYieldPending to true. So now that we have exited the
+                         * critical section check if xYieldPending is true, and
+                         * if so yield. */
+                        if( xYieldCurrentTask != pdFALSE )
+                        {
+                            portYIELD();
+                        }
+                    #else
+                        portENABLE_INTERRUPTS();
+                    #endif /* ( configNUM_CORES > 1 ) */
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
                 }
             }
             else
@@ -4713,27 +4722,30 @@ static void prvResetNextTaskUnblockTime( void )
              * does not match a previous call to vTaskEnterCritical(). */
             configASSERT( pxCurrentTCB->uxCriticalNesting > 0U );
 
-            if( pxCurrentTCB->uxCriticalNesting > 1U )
-            {
-                ( pxCurrentTCB->uxCriticalNesting )--;
-            }
-            else if( pxCurrentTCB->uxCriticalNesting == 1U )
+            if( pxCurrentTCB->uxCriticalNesting > 0U )
             {
                 ( pxCurrentTCB->uxCriticalNesting )--;
 
-                /* Get the xYieldPending stats inside the critical section. */
-                xYieldCurrentTask = xYieldPendings[ portGET_CORE_ID() ];
-
-                portRELEASE_ISR_LOCK();
-                portCLEAR_INTERRUPT_MASK( uxSavedInterruptStatus );
-
-                /* When a task yields in a critical section it just sets
-                 * xYieldPending to true. So now that we have exited the
-                 * critical section check if xYieldPending is true, and
-                 * if so yield. */
-                if( xYieldCurrentTask != pdFALSE )
+                if( pxCurrentTCB->uxCriticalNesting == 0U )
                 {
-                    portYIELD();
+                    /* Get the xYieldPending stats inside the critical section. */
+                    xYieldCurrentTask = xYieldPendings[ portGET_CORE_ID() ];
+
+                    portRELEASE_ISR_LOCK();
+                    portCLEAR_INTERRUPT_MASK( uxSavedInterruptStatus );
+
+                    /* When a task yields in a critical section it just sets
+                     * xYieldPending to true. So now that we have exited the
+                     * critical section check if xYieldPending is true, and
+                     * if so yield. */
+                    if( xYieldCurrentTask != pdFALSE )
+                    {
+                        portYIELD();
+                    }
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
                 }
             }
             else

--- a/tasks.c
+++ b/tasks.c
@@ -612,6 +612,84 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
 /*-----------------------------------------------------------*/
 
+#if ( configNUM_CORES > 1 )
+    static void prvCheckForRunStateChange( void )
+    {
+        UBaseType_t uxPrevCriticalNesting;
+        UBaseType_t uxPrevSchedulerSuspended;
+        TCB_t * pxThisTCB;
+
+        /* This function should not be called in ISR. If the task on the current
+         * core is no longer running, then vTaskSwitchContext() probably should
+         * be run before returning, but we don't have a way to force that to happen
+         * from here. */
+        configASSERT( portCHECK_IF_IN_ISR() );
+
+        /* This function is always called with interrupts disabled
+         * so this is safe. */
+        pxThisTCB = pxCurrentTCBs[ portGET_CORE_ID() ];
+
+        while( pxThisTCB->xTaskRunState == taskTASK_YIELDING )
+        {
+            /* We are only here if we just entered a critical section
+            * or if we just suspended the scheduler, and another task
+            * has requested that we yield.
+            *
+            * This is slightly complicated since we need to save and restore
+            * the suspension and critical nesting counts, as well as release
+            * and reacquire the correct locks. And then do it all over again
+            * if our state changed again during the reacquisition. */
+
+            uxPrevCriticalNesting = pxThisTCB->uxCriticalNesting;
+            uxPrevSchedulerSuspended = uxSchedulerSuspended;
+
+            /* this must only be called the first time we enter into a critical
+             * section, otherwise it could context switch in the middle of a
+             * critical section. */
+            configASSERT( uxPrevCriticalNesting + uxPrevSchedulerSuspended == 1U );
+
+            uxSchedulerSuspended = 0U;
+
+            if( uxPrevCriticalNesting > 0U )
+            {
+                pxThisTCB->uxCriticalNesting = 0U;
+                portRELEASE_ISR_LOCK();
+                portRELEASE_TASK_LOCK();
+            }
+            else
+            {
+                /* uxPrevSchedulerSuspended must be 1 */
+                portRELEASE_TASK_LOCK();
+            }
+
+            portMEMORY_BARRIER();
+            configASSERT( pxThisTCB->xTaskRunState == taskTASK_YIELDING );
+
+            portENABLE_INTERRUPTS();
+
+            /* Enabling interrupts should cause this core to immediately
+             * service the pending interrupt and yield. If the run state is still
+             * yielding here then that is a problem. */
+            configASSERT( pxThisTCB->xTaskRunState != taskTASK_YIELDING );
+
+            portDISABLE_INTERRUPTS();
+            portGET_TASK_LOCK();
+            portGET_ISR_LOCK();
+            pxCurrentTCB->uxCriticalNesting = uxPrevCriticalNesting;
+            uxSchedulerSuspended = uxPrevSchedulerSuspended;
+
+            if( uxPrevCriticalNesting == 0U )
+            {
+                /* uxPrevSchedulerSuspended must be 1 */
+                configASSERT( uxPrevSchedulerSuspended != ( UBaseType_t ) pdFALSE );
+                portRELEASE_ISR_LOCK();
+            }
+        }
+    }
+#endif
+
+/*-----------------------------------------------------------*/
+
 /* SMP_TODO : This is a temporay implementation for compilation.
  * Update this function in another commit. */
 #if ( configUSE_PORT_OPTIMISED_TASK_SELECTION == 0 ) && ( configNUM_CORES > 1 )
@@ -4500,6 +4578,14 @@ static void prvResetNextTaskUnblockTime( void )
 
         if( xSchedulerRunning != pdFALSE )
         {
+            #if ( configNUM_CORES > 1 )
+                if( pxCurrentTCB->uxCriticalNesting == 0U )
+                {
+                    portGET_TASK_LOCK();
+                    portGET_ISR_LOCK();
+                }
+            #endif
+
             ( pxCurrentTCB->uxCriticalNesting )++;
 
             /* This is not the interrupt safe version of the enter critical
@@ -4511,6 +4597,95 @@ static void prvResetNextTaskUnblockTime( void )
             if( pxCurrentTCB->uxCriticalNesting == 1 )
             {
                 portASSERT_IF_IN_ISR();
+                #if ( configNUM_CORES > 1 )
+                    /* The only time there would be a problem is if this is called
+                     * before a context switch and vTaskExitCritical() is called
+                     * after pxCurrentTCB changes. Therefore this should not be
+                     * used within vTaskSwitchContext(). */
+                    prvCheckForRunStateChange();
+                #endif
+            }
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
+    }
+
+#endif /* portCRITICAL_NESTING_IN_TCB */
+
+/*-----------------------------------------------------------*/
+
+#if ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUM_CORES > 1 )
+
+    UBaseType_t vTaskEnterCriticalFromISR( void )
+    {
+        UBaseType_t uxSavedInterruptStatus = 0;
+
+        if( xSchedulerRunning != pdFALSE )
+        {
+            uxSavedInterruptStatus = portSET_INTERRUPT_MASK();
+
+            if( pxCurrentTCB->uxCriticalNesting == 0U )
+            {
+                portGET_ISR_LOCK();
+            }
+
+            ( pxCurrentTCB->uxCriticalNesting )++;
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
+        return uxSavedInterruptStatus;
+    }
+
+#endif /* portCRITICAL_NESTING_IN_TCB */
+/*-----------------------------------------------------------*/
+
+#if ( portCRITICAL_NESTING_IN_TCB == 1 )
+
+    void vTaskExitCritical( void )
+    {
+        BaseType_t xCoreID;
+        BaseType_t xYieldForCurrentCore;
+
+        if( xSchedulerRunning != pdFALSE )
+        {
+            /* If pxCurrentTCB->uxCriticalNesting is zero then this function
+             * does not match a previous call to vTaskEnterCritical(). */
+            configASSERT( pxCurrentTCB->uxCriticalNesting > 0U );
+
+            if( pxCurrentTCB->uxCriticalNesting > 1U )
+            {
+                ( pxCurrentTCB->uxCriticalNesting )--;
+            }
+            else if( pxCurrentTCB->uxCriticalNesting == 1U )
+            {
+                ( pxCurrentTCB->uxCriticalNesting )--;
+
+                /* Get the xYieldPending stats inside the critical section. */
+                xCoreID = portGET_CORE_ID();
+                xYieldForCurrentCore = xYieldPendings[ xCoreID ];
+
+                #if ( configNUM_CORES > 1 )
+                    portRELEASE_ISR_LOCK();
+                    portRELEASE_TASK_LOCK();
+                #endif
+                portENABLE_INTERRUPTS();
+
+                /* When a task yields in a critical section it just sets
+                 * xYieldPending to true. So now that we have exited the
+                 * critical section check if xYieldPending is true, and
+                 * if so yield. */
+                if( xYieldForCurrentCore != pdFALSE )
+                {
+                    portYIELD_CORE( xCoreID );
+                }
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
             }
         }
         else
@@ -4522,23 +4697,41 @@ static void prvResetNextTaskUnblockTime( void )
 #endif /* portCRITICAL_NESTING_IN_TCB */
 /*-----------------------------------------------------------*/
 
-#if ( portCRITICAL_NESTING_IN_TCB == 1 )
+#if ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUM_CORES > 1 )
 
-    void vTaskExitCritical( void )
+    void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
+        BaseType_t xCoreID;
+        BaseType_t xYieldForCurrentCore;
+
         if( xSchedulerRunning != pdFALSE )
         {
-            if( pxCurrentTCB->uxCriticalNesting > 0U )
+            /* If pxCurrentTCB->uxCriticalNesting is zero then this function
+             * does not match a previous call to vTaskEnterCritical(). */
+            configASSERT( pxCurrentTCB->uxCriticalNesting > 0U );
+
+            if( pxCurrentTCB->uxCriticalNesting > 1U )
+            {
+                ( pxCurrentTCB->uxCriticalNesting )--;
+            }
+            else if( pxCurrentTCB->uxCriticalNesting == 1U )
             {
                 ( pxCurrentTCB->uxCriticalNesting )--;
 
-                if( pxCurrentTCB->uxCriticalNesting == 0U )
+                /* Get the xYieldPending stats inside the critical section. */
+                xCoreID = portGET_CORE_ID();
+                xYieldForCurrentCore = xYieldPendings[ xCoreID ];
+
+                portRELEASE_ISR_LOCK();
+                portCLEAR_INTERRUPT_MASK( uxSavedInterruptStatus );
+
+                /* When a task yields in a critical section it just sets
+                 * xYieldPending to true. So now that we have exited the
+                 * critical section check if xYieldPending is true, and
+                 * if so yield. */
+                if( xYieldForCurrentCore != pdFALSE )
                 {
-                    portENABLE_INTERRUPTS();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
+                    portYIELD_CORE( xCoreID );
                 }
             }
             else

--- a/tasks.c
+++ b/tasks.c
@@ -447,6 +447,12 @@ PRIVILEGED_DATA static volatile UBaseType_t uxSchedulerSuspended = ( UBaseType_t
 /* File private functions. --------------------------------*/
 
 /*
+ * Checks to see if another task moved the current task out of the ready
+ * list while it was waiting to enter a critical section and yields if so.
+ */
+static void prvCheckForRunStateChange( void );
+
+/*
  * Selects the highest priority available task
  */
 static BaseType_t prvSelectHighestPriorityTask( void );


### PR DESCRIPTION

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

* Add portSET_INTERRUPT_MASK/portLCEAR_INTERRUPT_MASK port macros. These are required for SMP porting
* Update vTaskEnterCritical and vTaskExitCritical functions for SMP
* Add vTaskEnterCriticalFromISR and vTaskExitCriticalFromISR for SMP

Example SMP critical section porting macro implementation in current commit
```C
#define portCRITICAL_NESTING_IN_TCB 1
#define portYIELD_CORE(a) vYieldCore(a)
#define portGET_CORE_ID() get_core_num()

#define portSET_INTERRUPT_MASK()                     ({               \
       uint32_t ulState;                                                  \
       __asm volatile ("mrs %0, PRIMASK" : "=r" (ulState)::);             \
       __asm volatile ( " cpsid i " ::: "memory" );                       \
       ulState;})

#define portCLEAR_INTERRUPT_MASK(ulState) __asm volatile ("msr PRIMASK,%0"::"r" (ulState) : )

#define portENTER_CRITICAL()                      vTaskEnterCritical()
#define portEXIT_CRITICAL()                       vTaskExitCritical()

#define portSET_INTERRUPT_MASK_FROM_ISR()         vTaskEnterCriticalFromISR()
#define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    vTaskExitCriticalFromISR( x )
```


Test Steps
-----------
<!-- Describe the steps to reproduce. -->
* Verify in RPI pico main_full demo
* Compile in RPI pico with configNUM_CORES = 2

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
