### PR TITLE
Merge suspend/resume scheduler from SMP to main

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -333,6 +333,16 @@
 
 #endif  /* portCLEAR_INTERRUPT_MASK */
 
+#ifndef portRELEASE_TASK_LOCK
+
+    #if ( configNUM_CORES == 1 )
+        #define portRELEASE_TASK_LOCK()
+    #else
+        #error portRELEASE_TASK_LOCK is required in SMP
+    #endif
+
+#endif  /* portRELEASE_TASK_LOCK */
+
 /* The timers module relies on xTaskGetSchedulerState(). */
 #if configUSE_TIMERS == 1
 

--- a/tasks.c
+++ b/tasks.c
@@ -2653,7 +2653,7 @@ BaseType_t xTaskResumeAll( void )
      * previous call to vTaskSuspendAll(). */
     configASSERT( uxSchedulerSuspended );
 
-    #if ( coreNUM_CORES > 1 )
+    #if ( configNUM_CORES > 1 )
         if( xSchedulerRunning != pdFALSE )
     #endif
     {

--- a/tasks.c
+++ b/tasks.c
@@ -2209,7 +2209,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
 
     BaseType_t xTaskResumeFromISR( TaskHandle_t xTaskToResume )
     {
-        BaseType_t xYieldRequired;
+        BaseType_t xYieldRequired = pdFALSE;
         BaseType_t xYieldCoreID;
         TCB_t * const pxTCB = xTaskToResume;
         UBaseType_t uxSavedInterruptStatus;

--- a/tasks.c
+++ b/tasks.c
@@ -2649,14 +2649,14 @@ BaseType_t xTaskResumeAll( void )
     TCB_t * pxTCB = NULL;
     BaseType_t xAlreadyYielded = pdFALSE;
 
-    /* If uxSchedulerSuspended is zero then this function does not match a
-     * previous call to vTaskSuspendAll(). */
-    configASSERT( uxSchedulerSuspended );
-
     #if ( configNUM_CORES > 1 )
         if( xSchedulerRunning != pdFALSE )
     #endif
     {
+        /* If uxSchedulerSuspended is zero then this function does not match a
+         * previous call to vTaskSuspendAll(). */
+        configASSERT( uxSchedulerSuspended );
+
         /* It is possible that an ISR caused a task to be removed from an event
          * list while the scheduler was suspended.  If this was the case then the
          * removed task will have been added to the xPendingReadyList.  Once the

--- a/tasks.c
+++ b/tasks.c
@@ -2650,6 +2650,10 @@ BaseType_t xTaskResumeAll( void )
     TCB_t * pxTCB = NULL;
     BaseType_t xAlreadyYielded = pdFALSE;
 
+    /* If uxSchedulerSuspended is zero then this function does not match a
+     * previous call to vTaskSuspendAll(). */
+    configASSERT( uxSchedulerSuspended );
+
     /* It is possible that an ISR caused a task to be removed from an event
      * list while the scheduler was suspended.  If this was the case then the
      * removed task will have been added to the xPendingReadyList.  Once the
@@ -2660,10 +2664,6 @@ BaseType_t xTaskResumeAll( void )
         BaseType_t xCoreID;
 
         xCoreID = portGET_CORE_ID();
-
-        /* If uxSchedulerSuspended is zero then this function does not match a
-         * previous call to vTaskSuspendAll(). */
-        configASSERT( uxSchedulerSuspended );
 
         --uxSchedulerSuspended;
         portRELEASE_TASK_LOCK();

--- a/tasks.c
+++ b/tasks.c
@@ -2653,10 +2653,6 @@ BaseType_t xTaskResumeAll( void )
         if( xSchedulerRunning != pdFALSE )
     #endif
     {
-        /* If uxSchedulerSuspended is zero then this function does not match a
-         * previous call to vTaskSuspendAll(). */
-        configASSERT( uxSchedulerSuspended );
-
         /* It is possible that an ISR caused a task to be removed from an event
          * list while the scheduler was suspended.  If this was the case then the
          * removed task will have been added to the xPendingReadyList.  Once the
@@ -2667,6 +2663,10 @@ BaseType_t xTaskResumeAll( void )
             BaseType_t xCoreID;
 
             xCoreID = portGET_CORE_ID();
+
+            /* If uxSchedulerSuspended is zero then this function does not match a
+             * previous call to vTaskSuspendAll(). */
+            configASSERT( uxSchedulerSuspended );
 
             --uxSchedulerSuspended;
             portRELEASE_TASK_LOCK();

--- a/tasks.c
+++ b/tasks.c
@@ -2175,7 +2175,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
         #if ( configNUM_CORES == 1 )
             /* The parameter cannot be NULL as it is impossible to resume the
              * currently executing task. */
-            if( ( pxTCB != pxCurrentTCB ) && ( pxTCB != NULL ) )
+            if( ( taskTASK_IS_RUNNING( pxTCB ) == pdFALSE ) && ( pxTCB != NULL ) )
         #else
             /* The parameter cannot be NULL as it is impossible to resume the
              * currently executing task. It is also impossible to resume a task

--- a/tasks.c
+++ b/tasks.c
@@ -2689,9 +2689,22 @@ BaseType_t xTaskResumeAll( void )
                         listREMOVE_ITEM( &( pxTCB->xStateListItem ) );
                         prvAddTaskToReadyList( pxTCB );
 
-                        /* All appropriate tasks yield at the moment a task is added to xPendingReadyList.
-                         * If the current core yielded then vTaskSwitchContext() has already been called
-                         * which sets xYieldPendings for the current core to pdTRUE. */
+                        #if ( configNUM_CORES == 1 )
+                            /* If the moved task has a priority higher than the current
+                             * task then a yield must be performed. */
+                            if( pxTCB->uxPriority >= pxCurrentTCB->uxPriority )
+                            {
+                                xYieldPendings[ xCoreID ] = pdTRUE;
+                            }
+                            else
+                            {
+                                mtCOVERAGE_TEST_MARKER();
+                            }
+                        #else
+                            /* All appropriate tasks yield at the moment a task is added to xPendingReadyList.
+                             * If the current core yielded then vTaskSwitchContext() has already been called
+                             * which sets xYieldPendings for the current core to pdTRUE. */
+                        #endif
                     }
 
                     if( pxTCB != NULL )

--- a/tasks.c
+++ b/tasks.c
@@ -2172,12 +2172,18 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
         /* It does not make sense to resume the calling task. */
         configASSERT( xTaskToResume );
 
-        /* The parameter cannot be NULL as it is impossible to resume the
-         * currently executing task. It is also impossible to resume a task
-         * that is actively running on another core but it is too dangerous
-         * to check their run state here. Safer to get into a critical section
-         * and check if it is actually suspended or not below. */
-        if( pxTCB != NULL )
+        #if ( configNUM_CORES == 1 )
+            /* The parameter cannot be NULL as it is impossible to resume the
+             * currently executing task. */
+            if( ( pxTCB != pxCurrentTCB ) && ( pxTCB != NULL ) )
+        #else
+            /* The parameter cannot be NULL as it is impossible to resume the
+             * currently executing task. It is also impossible to resume a task
+             * that is actively running on another core but it is too dangerous
+             * to check their run state here. Safer to get into a critical section
+             * and check if it is actually suspended or not below. */
+            if( pxTCB != NULL )
+        #endif
         {
             taskENTER_CRITICAL();
             {

--- a/tasks.c
+++ b/tasks.c
@@ -428,7 +428,11 @@ const volatile UBaseType_t uxTopUsedPriority = configMAX_PRIORITIES - 1U;
  * moves the task's event list item into the xPendingReadyList, ready for the
  * kernel to move the task from the pending ready list into the real ready list
  * when the scheduler is unsuspended.  The pending ready list itself can only be
- * accessed from a critical section. */
+ * accessed from a critical section.
+ *
+ * Updates to uxSchedulerSuspended must be protected by both the task and ISR locks and
+ * must not be done by an ISR. Reads must be protected by either lock and may be done by
+ * either an ISR or a task. */
 PRIVILEGED_DATA static volatile UBaseType_t uxSchedulerSuspended = ( UBaseType_t ) pdFALSE;
 
 #if ( configGENERATE_RUN_TIME_STATS == 1 )

--- a/tasks.c
+++ b/tasks.c
@@ -2485,22 +2485,66 @@ void vTaskEndScheduler( void )
 
 void vTaskSuspendAll( void )
 {
-    /* A critical section is not required as the variable is of type
-     * BaseType_t.  Please read Richard Barry's reply in the following link to a
-     * post in the FreeRTOS support forum before reporting this as a bug! -
-     * https://goo.gl/wu4acr */
+    #if ( configNUM_CORES == 1 )
+        {
+            /* A critical section is not required as the variable is of type
+             * BaseType_t.  Please read Richard Barry's reply in the following link to a
+             * post in the FreeRTOS support forum before reporting this as a bug! -
+             * https://goo.gl/wu4acr */
 
-    /* portSOFTWARE_BARRIER() is only implemented for emulated/simulated ports that
-     * do not otherwise exhibit real time behaviour. */
-    portSOFTWARE_BARRIER();
+            /* portSOFTWARE_BARRIER() is only implemented for emulated/simulated ports that
+             * do not otherwise exhibit real time behaviour. */
+            portSOFTWARE_BARRIER();
 
-    /* The scheduler is suspended if uxSchedulerSuspended is non-zero.  An increment
-     * is used to allow calls to vTaskSuspendAll() to nest. */
-    ++uxSchedulerSuspended;
+            /* The scheduler is suspended if uxSchedulerSuspended is non-zero.  An increment
+             * is used to allow calls to vTaskSuspendAll() to nest. */
+            ++uxSchedulerSuspended;
 
-    /* Enforces ordering for ports and optimised compilers that may otherwise place
-     * the above increment elsewhere. */
-    portMEMORY_BARRIER();
+            /* Enforces ordering for ports and optimised compilers that may otherwise place
+             * the above increment elsewhere. */
+            portMEMORY_BARRIER();
+        }
+    #else
+        {
+            UBaseType_t ulState;
+
+            /* This must only be called from within a task */
+            portASSERT_IF_IN_ISR();
+
+            if( xSchedulerRunning != pdFALSE )
+            {
+                /* writes to uxSchedulerSuspended must be protected by both the task AND ISR locks.
+                 * We must disable interrupts before we grab the locks in the event that this task is
+                 * interrupted and switches context before incrementing uxSchedulerSuspended.
+                 * It is safe to re-enable interrupts after releasing the ISR lock and incrementing
+                 * uxSchedulerSuspended since that will prevent context switches. */
+                ulState = portSET_INTERRUPT_MASK();
+
+                /* portSOFRWARE_BARRIER() is only implemented for emulated/simulated ports that
+                 * do not otherwise exhibit real time behaviour. */
+                portSOFTWARE_BARRIER();
+
+                portGET_TASK_LOCK();
+                portGET_ISR_LOCK();
+
+                /* The scheduler is suspended if uxSchedulerSuspended is non-zero.  An increment
+                 * is used to allow calls to vTaskSuspendAll() to nest. */
+                ++uxSchedulerSuspended;
+                portRELEASE_ISR_LOCK();
+
+                if( ( uxSchedulerSuspended == 1U ) && ( pxCurrentTCB->uxCriticalNesting == 0U ) )
+                {
+                    prvCheckForRunStateChange();
+                }
+
+                portCLEAR_INTERRUPT_MASK( ulState );
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+        }
+    #endif  /* ( configNUM_CORES == 1 ) */
 }
 /*----------------------------------------------------------*/
 
@@ -2572,10 +2616,6 @@ BaseType_t xTaskResumeAll( void )
     TCB_t * pxTCB = NULL;
     BaseType_t xAlreadyYielded = pdFALSE;
 
-    /* If uxSchedulerSuspended is zero then this function does not match a
-     * previous call to vTaskSuspendAll(). */
-    configASSERT( uxSchedulerSuspended );
-
     /* It is possible that an ISR caused a task to be removed from an event
      * list while the scheduler was suspended.  If this was the case then the
      * removed task will have been added to the xPendingReadyList.  Once the
@@ -2583,7 +2623,16 @@ BaseType_t xTaskResumeAll( void )
      * tasks from this list into their appropriate ready list. */
     taskENTER_CRITICAL();
     {
+        BaseType_t xCoreID;
+
+        xCoreID = portGET_CORE_ID();
+
+        /* If uxSchedulerSuspended is zero then this function does not match a
+         * previous call to vTaskSuspendAll(). */
+        configASSERT( uxSchedulerSuspended );
+
         --uxSchedulerSuspended;
+        portRELEASE_TASK_LOCK();
 
         if( uxSchedulerSuspended == ( UBaseType_t ) pdFALSE )
         {
@@ -2599,17 +2648,9 @@ BaseType_t xTaskResumeAll( void )
                     listREMOVE_ITEM( &( pxTCB->xStateListItem ) );
                     prvAddTaskToReadyList( pxTCB );
 
-                    /* If the moved task has a priority higher than or equal to
-                     * the current task then a yield must be performed. */
-                    if( pxTCB->uxPriority >= pxCurrentTCB->uxPriority )
-                    {
-                        /* SMP_TODO : Fix this when reviewing other commit. */
-                        xYieldPendings[ portGET_CORE_ID() ] = pdTRUE;
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
+                    /* All appropriate tasks yield at the moment a task is added to xPendingReadyList.
+                     * If the current core yielded then vTaskSwitchContext() has already been called
+                     * which sets xYieldPendings for the current core to pdTRUE. */
                 }
 
                 if( pxTCB != NULL )
@@ -2626,7 +2667,12 @@ BaseType_t xTaskResumeAll( void )
                 /* If any ticks occurred while the scheduler was suspended then
                  * they should be processed now.  This ensures the tick count does
                  * not  slip, and that any delayed tasks are resumed at the correct
-                 * time. */
+                 * time.
+                 *
+                 * It should be safe to call xTaskIncrementTick here from any core
+                 * since we are in a critical section and xTaskIncrementTick itself
+                 * protects itself within a critical section. Suspending the scheduler
+                 * from any core causes xTaskIncrementTick to increment uxPendedCounts. */
                 {
                     TickType_t xPendedCounts = xPendedTicks; /* Non-volatile copy. */
 
@@ -2636,8 +2682,9 @@ BaseType_t xTaskResumeAll( void )
                         {
                             if( xTaskIncrementTick() != pdFALSE )
                             {
-                                /* SMP_TODO : Fix this when reviewing other commit. */
-                                xYieldPendings[ portGET_CORE_ID() ] = pdTRUE;
+                                /* other cores are interrupted from
+                                 * within xTaskIncrementTick(). */
+                                xYieldPendings[ xCoreID ] = pdTRUE;
                             }
                             else
                             {
@@ -2655,15 +2702,17 @@ BaseType_t xTaskResumeAll( void )
                     }
                 }
 
-                /* SMP_TODO : Fix this when reviewing other commit. */
-                if(  xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
+                if( xYieldPendings[ xCoreID ] != pdFALSE )
                 {
                     #if ( configUSE_PREEMPTION != 0 )
                     {
                         xAlreadyYielded = pdTRUE;
                     }
                     #endif
-                    taskYIELD_IF_USING_PREEMPTION();
+
+                    #if ( configNUM_CORES == 1 )
+                        taskYIELD_IF_USING_PREEMPTION();
+                    #endif /* ( configNUM_CORES == 1 ) */
                 }
                 else
                 {


### PR DESCRIPTION
Merge suspend/resume scheduler from SMP to main

Description
-----------
Merge the following function from SMP to main
* vTaskSuspendAll
* xTaskResumeAll
* vTaskResume
* xTaskResumeFromISR

Test Steps
-----------
* Raspberry pi pico single core main_full
* WIN32-msvc main_full
* Compiled with raspberry pi pico SMP project

Related Issue
-----------
<!-- If any, please provide issue ID. -->

Performance Comparison Test
-----------
* The table list performance difference between smp-dev-idleTask and smp-dev-suspend-resume-scheduler.
* The new function prvYieldForTask is introduced. This function is used in vTaskResume and vTaskResumeFromISR. The effect can be minimized by ( -Ofast ).

|                                                  | smp-dev-suspend-resume-scheduler ( -O0 ) | smp-dev-suspend-resume-scheduler ( -Ofast ) |
| ------------------------------------------------ | -------------------------------- | -------------------------------- |
| PerfTest\_vTaskStartScheduler                    | 7                                | 0                                |
| PerfTest\_vTaskDelete\_DeleteCurrentTask         | 0                                | 0                                |
| PerfTest\_vTaskDelete\_DeleteOtherTask           | 11                               | 0                                |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskHigh     | 0                                | 0                                |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskLow      | 0                                | 0                                |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskHigh   | 0                                | 0                                |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskLow    | 0                                | 0                                |
| PerfTest\_vTaskPrioritySet\_TaskSwitch           | 0                                | 0                                |
| PerfTest\_vTaskSuspend\_SuspendCurrent           | 0                                | 0                                |
| PerfTest\_vTaskSuspend\_SuspendOther             | 0                                | 0                                |
| PerfTest\_vTaskSuspend\_TaskSwitch               | 28                               | \-4                              |
| PerfTest\_vTaskResume\_ResumeLowTask             | 34                               | 8                                |
| PerfTest\_vTaskResume\_ResumeHighTask            | 30                               | \-4                              |
| PerfTest\_xTaskResumeFromISR\_ResumeLowTask      | 82                               | 12                               |
| PerfTest\_xTaskResumeFromISR\_ResumeHighTask     | 82                               | 2                                |
| PerfTest\_xTaskResumeFromISR\_TaskSwitch         | 82                               | 2                                |
| PerfTest\_xTaskAbortDelay\_HighPriorityTask      | 8                                | 0                                |
| PerfTest\_xTaskAbortDelay\_LowPriorityTask       | 8                                | 0                                |
| PerfTest\_xTaskAbortDelay\_TaskSwitch            | 16                               | 0                                |
| PerfTest\_xTaskIncrementTick\_SchedulerSuspended | 0                                | 0                                |
| PerfTest\_xTaskIncrementTick\_SchedulerRunning   | 0                                | 0                                |
| PerfTest\_xTaskIncrementTick\_TaskSwitch         | 0                                | 0                                |
| PerfTest\_vTaskSwtichContext\_SwitchToCurrent    | 0                                | 0                                |
| PerfTest\_vTaskSwtichContext\_SwitchToOther      | \-1                              | 0                                |
| PerfTest\_vTaskSwtichContext\_TaskSwitch         | 0                                | 0                                |
| PerfTest\_xQueueSend\_UnblockHighTask            | 0                                | 0                                |
| PerfTest\_xQueueSend\_UnblockLowTask             | 0                                | 0                                |
| PerfTest\_xQueueSend\_TaskSwitch                 | 8                                | \-1                              |
| PerfTest\_xEventGroupsSetBits\_unblockHighTask   | 8                                | 0                                |
| PerfTest\_xEventGroupsSetBits\_unblockLowTask    | 8                                | 0                                |
| PerfTest\_xEventGroupSetBits\_TaskSwitch         | 16                               | 0                                |
| PerfTest\_xTaskNotifyGive\_UnblockHighTask       | 0                                | 0                                |
| PerfTest\_xTaskNotifyGive\_UnblockLowTask        | \-2                              | 0                                |
| PerfTest\_xTaskNotifyGive\_TaskSwitch            | \-1                              | 0                                |
| PerfTest\_xTaskNotifyFromISR\_NotifyHighTask     | 0                                | 0                                |
| PerfTest\_xTaskNotifyFromISR\_NotifyLowTask      | 0                                | 0                                |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyHighTask | 0                                | 0                                |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyLowTask  | 0                                | 0                                |
| xAvailableHeapSpaceInBytes                       | 0                                | 0                                |
| xNumberOfSuccessfulAllocations                   | 0                                | 0                                |
| xNumberOfSuccessfulFrees                         | 0                                | 0                                |
| xMinimumEverFreeBytesRemaining                   | 0                                | 0                                |
| text                                             | 112                              | 16                               |
| data                                             | 0                                | 0                                |
| bss                                              | 0                                | 0                                |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
