### PR TITLE
Update prvYieldForTask usage in kernel APIs

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3819,7 +3819,9 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
         /* Mark that a yield is pending in case the user is not using the
          * "xHigherPriorityTaskWoken" parameter to an ISR safe FreeRTOS function. */
         #if ( configUSE_PREEMPTION == 1 )
+        {
             xYieldPendings[ xYieldCoreID ] = pdTRUE;
+        }
         #endif
     }
     else
@@ -3871,6 +3873,7 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
     prvAddTaskToReadyList( pxUnblockedTCB );
 
     #if ( configUSE_PREEMPTION == 1 )
+    {
         taskENTER_CRITICAL();
         {
             xYieldCoreID = prvYieldForTask( pxUnblockedTCB, pdFALSE, pdFALSE );
@@ -3880,6 +3883,7 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
             }
         }
         taskEXIT_CRITICAL();
+    }
     #endif  /* ( configUSE_PREEMPTION == 1 ) */
 }
 /*-----------------------------------------------------------*/
@@ -4732,7 +4736,9 @@ static void prvResetNextTaskUnblockTime( void )
             UBaseType_t uxSavedInterruptStatus = 0;
 
             uxSavedInterruptStatus = portSET_INTERRUPT_MASK();
-            xReturn = pxCurrentTCBs[ portGET_CORE_ID() ];
+            {
+                xReturn = pxCurrentTCBs[ portGET_CORE_ID() ];
+            }
             portCLEAR_INTERRUPT_MASK( uxSavedInterruptStatus );
 
             return xReturn;
@@ -5822,7 +5828,9 @@ TickType_t uxTaskResetEventItemValue( void )
                 /* The notified task has a priority above the currently
                  * executing task so a yield is required. */
                 #if ( configUSE_PREEMPTION == 1 )
+                {
                     ( void ) prvYieldForTask( pxTCB, pdFALSE, pdTRUE );
+                }
                 #endif /* ( configUSE_PREEMPTION == 1 ) */
             }
             else
@@ -5962,7 +5970,9 @@ TickType_t uxTaskResetEventItemValue( void )
                      * using the "xHigherPriorityTaskWoken" parameter to an ISR
                      * safe FreeRTOS function. */
                     #if ( configUSE_PREEMPTION == 1 )
+                    {
                         xYieldPendings[ xYieldCoreId ] = pdTRUE;
+                    }
                     #endif /* ( configUSE_PREEMPTION == 1 ) */
                 }
                 else
@@ -6055,7 +6065,9 @@ TickType_t uxTaskResetEventItemValue( void )
                      * using the "xHigherPriorityTaskWoken" parameter in an ISR
                      * safe FreeRTOS function. */
                     #if ( configUSE_PREEMPTION == 1 )
+                    {
                         xYieldPendings[ xYieldCoreId ] = pdTRUE;
+                    }
                     #endif /* ( configUSE_PREEMPTION == 1 ) */
                 }
                 else

--- a/tasks.c
+++ b/tasks.c
@@ -5783,7 +5783,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 /* The notified task has a priority above the currently
                  * executing task so a yield is required. */
                 #if ( configUSE_PREEMPTION == 1 )
-                    prvYieldForTask( pxTCB, pdFALSE, pdTRUE );
+                    ( void ) prvYieldForTask( pxTCB, pdFALSE, pdTRUE );
                 #endif /* ( configUSE_PREEMPTION == 1 ) */
             }
             else


### PR DESCRIPTION
Update prvYieldForTask usage in kernel APIs

Description
-----------
Merge prvYieldForTask in the following functions
* xTaskAbortDelay
* xTaskRemoveFromEventList
* vTaskRemoveFromUnorderedEventList
* xTaskGenericNotify
* xTaskGenericNotifyFromISR
* vTaskGenericNotifyGiveFromISR

Merge xTaskGetCurrentTaskHandle and xTaskGetCurrentTaskHandleCPU from SMP


Test Steps
-----------
* Run main_full in single core RP2040
* Run main_full in single core WIN32-MSVC
* Compile main_full in SMP RP2040

Related Issue
-----------
<!-- If any, please provide issue ID. -->

Performance Comparison Test
-----------
* Compared with smp-dev-increment-tick branch.
* The usage of prvYieldForTask increase the execution time. This can be reduced by ( -Ofast ).
* Critical section are used in xTaskAbortDelay and vTaskRemoveFromUnorderedEventList. This cause extra 40 cycles overhead.

|                                                  | smp-dev-prvYieldForTask-usage | smp-dev-prvYieldForTask-usage |
| ------------------------------------------------ | ----------------------------- | ----------------------------- |
| PerfTest\_vTaskStartScheduler                    | 1                             | 0                             |
| PerfTest\_vTaskDelete\_DeleteCurrentTask         | 0                             | 0                             |
| PerfTest\_vTaskDelete\_DeleteOtherTask           | \-1                           | 0                             |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskHigh     | 0                             | 0                             |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskLow      | 1                             | 0                             |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskHigh   | 0                             | 0                             |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskLow    | 0                             | 0                             |
| PerfTest\_vTaskPrioritySet\_TaskSwitch           | 0                             | 0                             |
| PerfTest\_vTaskSuspend\_SuspendCurrent           | 0                             | 0                             |
| PerfTest\_vTaskSuspend\_SuspendOther             | 0                             | 0                             |
| PerfTest\_vTaskSuspend\_TaskSwitch               | 0                             | 0                             |
| PerfTest\_vTaskResume\_ResumeLowTask             | 0                             | 0                             |
| PerfTest\_vTaskResume\_ResumeHighTask            | 0                             | 0                             |
| PerfTest\_xTaskResumeFromISR\_ResumeLowTask      | 0                             | 0                             |
| PerfTest\_xTaskResumeFromISR\_ResumeHighTask     | 0                             | 0                             |
| PerfTest\_xTaskResumeFromISR\_TaskSwitch         | 0                             | 0                             |
| PerfTest\_xTaskAbortDelay\_HighPriorityTask      | 146                           | 42                            |
| PerfTest\_xTaskAbortDelay\_LowPriorityTask       | 136                           | 40                            |
| PerfTest\_xTaskAbortDelay\_TaskSwitch            | 147                           | 40                            |
| PerfTest\_xTaskIncrementTick\_SchedulerSuspended | 0                             | 0                             |
| PerfTest\_xTaskIncrementTick\_SchedulerRunning   | 0                             | 0                             |
| PerfTest\_xTaskIncrementTick\_TaskSwitch         | 17                            | \-16                          |
| PerfTest\_vTaskSwtichContext\_SwitchToCurrent    | 0                             | 0                             |
| PerfTest\_vTaskSwtichContext\_SwitchToOther      | 2                             | 0                             |
| PerfTest\_vTaskSwtichContext\_TaskSwitch         | 0                             | 0                             |
| PerfTest\_xQueueSend\_UnblockHighTask            | 69                            | 0                             |
| PerfTest\_xQueueSend\_UnblockLowTask             | 55                            | 0                             |
| PerfTest\_xQueueSend\_TaskSwitch                 | 69                            | 0                             |
| PerfTest\_xEventGroupsSetBits\_unblockHighTask   | 147                           | 42                            |
| PerfTest\_xEventGroupsSetBits\_unblockLowTask    | 132                           | 44                            |
| PerfTest\_xEventGroupSetBits\_TaskSwitch         | 148                           | 42                            |
| PerfTest\_xTaskNotifyGive\_UnblockHighTask       | 47                            | 0                             |
| PerfTest\_xTaskNotifyGive\_UnblockLowTask        | 51                            | \-1                           |
| PerfTest\_xTaskNotifyGive\_TaskSwitch            | 48                            | 0                             |
| PerfTest\_xTaskNotifyFromISR\_NotifyHighTask     | 94                            | 0                             |
| PerfTest\_xTaskNotifyFromISR\_NotifyLowTask      | 71                            | 0                             |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyHighTask | 92                            | 0                             |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyLowTask  | 70                            | 0                             |
| xAvailableHeapSpaceInBytes                       | 0                             | 0                             |
| xNumberOfSuccessfulAllocations                   | 0                             | 0                             |
| xNumberOfSuccessfulFrees                         | 0                             | 0                             |
| xMinimumEverFreeBytesRemaining                   | 0                             | 0                             |
| text                                             | 32                            | 0                             |
| data                                             | 0                             | 0                             |
| bss                                              | 0                             | 0                             |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
