### PR TITLE
Merge prvAddNewTaskToReadyList from SMP

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -1377,12 +1377,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                 {
                     if( pxCurrentTCB->uxPriority <= pxNewTCB->uxPriority )
                     {
-                        /* SMP_TODO : fix this in other PR. */
-                        #if ( configNUM_CORES == 1 )
-                            pxCurrentTCB = pxNewTCB;
-                        #else
-                            pxCurrentTCBs[ portGET_CORE_ID() ] = pxNewTCB;
-                        #endif
+                        pxCurrentTCB = pxNewTCB;
                     }
                     else
                     {
@@ -1390,21 +1385,21 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                     }
                 }
             #else
-            if( pxNewTCB->xTaskAttribute & taskATTRIBUTE_IS_IDLE )
-            {
-                BaseType_t xCoreID;
-
-                /* Check if a core is free. */
-                for( xCoreID = ( UBaseType_t ) 0; xCoreID < ( UBaseType_t ) configNUM_CORES; xCoreID++ )
+                if( pxNewTCB->xTaskAttribute & taskATTRIBUTE_IS_IDLE )
                 {
-                    if( pxCurrentTCBs[ xCoreID ] == NULL )
+                    BaseType_t xCoreID;
+
+                    /* Check if a core is free. */
+                    for( xCoreID = ( UBaseType_t ) 0; xCoreID < ( UBaseType_t ) configNUM_CORES; xCoreID++ )
                     {
-                        pxNewTCB->xTaskRunState = xCoreID;
-                        pxCurrentTCBs[ xCoreID ] = pxNewTCB;
-                        break;
+                        if( pxCurrentTCBs[ xCoreID ] == NULL )
+                        {
+                            pxNewTCB->xTaskRunState = xCoreID;
+                            pxCurrentTCBs[ xCoreID ] = pxNewTCB;
+                            break;
+                        }
                     }
                 }
-            }
             #endif
         }
 

--- a/tasks.c
+++ b/tasks.c
@@ -1352,17 +1352,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
     {
         uxCurrentNumberOfTasks++;
 
-        if( pxCurrentTCB == NULL )
+        if( xSchedulerRunning == pdFALSE )
         {
-            /* There are no other tasks, or all the other tasks are in
-             * the suspended state - make this the current task. */
-            /* SMP_TODO : fix this in other PR. */
-            #if ( configNUM_CORES == 1 )
-                pxCurrentTCB = pxNewTCB;
-            #else
-                pxCurrentTCBs[ portGET_CORE_ID() ] = pxNewTCB;
-            #endif
-
             if( uxCurrentNumberOfTasks == ( UBaseType_t ) 1 )
             {
                 /* This is the first task to be created so do the preliminary
@@ -1374,32 +1365,47 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
             {
                 mtCOVERAGE_TEST_MARKER();
             }
-        }
-        else
-        {
-            /* If the scheduler is not already running, make this task the
-             * current task if it is the highest priority task to be created
-             * so far. */
-            if( xSchedulerRunning == pdFALSE )
-            {
-                if( pxCurrentTCB->uxPriority <= pxNewTCB->uxPriority )
+
+            #if ( configNUM_CORES == 1 )
+                if( pxCurrentTCB == NULL )
                 {
-                    /* SMP_TODO : fix this in other PR. */
-                    #if ( configNUM_CORES == 1 )
-                        pxCurrentTCB = pxNewTCB;
-                    #else
-                        pxCurrentTCBs[ portGET_CORE_ID() ] = pxNewTCB;
-                    #endif
+                    /* There are no other tasks, or all the other tasks are in
+                     * the suspended state - make this the current task. */
+                    pxCurrentTCB = pxNewTCB;
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    if( pxCurrentTCB->uxPriority <= pxNewTCB->uxPriority )
+                    {
+                        /* SMP_TODO : fix this in other PR. */
+                        #if ( configNUM_CORES == 1 )
+                            pxCurrentTCB = pxNewTCB;
+                        #else
+                            pxCurrentTCBs[ portGET_CORE_ID() ] = pxNewTCB;
+                        #endif
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
+                }
+            #else
+            if( pxNewTCB->xTaskAttribute & taskATTRIBUTE_IS_IDLE )
+            {
+                BaseType_t xCoreID;
+
+                /* Check if a core is free. */
+                for( xCoreID = ( UBaseType_t ) 0; xCoreID < ( UBaseType_t ) configNUM_CORES; xCoreID++ )
+                {
+                    if( pxCurrentTCBs[ xCoreID ] == NULL )
+                    {
+                        pxNewTCB->xTaskRunState = xCoreID;
+                        pxCurrentTCBs[ xCoreID ] = pxNewTCB;
+                        break;
+                    }
                 }
             }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
+            #endif
         }
 
         uxTaskNumber++;
@@ -1415,26 +1421,22 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
         prvAddTaskToReadyList( pxNewTCB );
 
         portSETUP_TCB( pxNewTCB );
-    }
-    taskEXIT_CRITICAL();
 
-    if( xSchedulerRunning != pdFALSE )
-    {
-        /* If the created task is of a higher priority than the current task
-         * then it should run now. */
-        if( pxCurrentTCB->uxPriority < pxNewTCB->uxPriority )
+        if( xSchedulerRunning != pdFALSE )
         {
-            taskYIELD_IF_USING_PREEMPTION();
+            /* If the created task is of a higher priority than another
+             * currently running task and preemption is on then it should
+             * run now. */
+            #if ( configUSE_PREEMPTION == 1 )
+                ( void ) prvYieldForTask( pxNewTCB, pdFALSE, pdTRUE );
+            #endif
         }
         else
         {
             mtCOVERAGE_TEST_MARKER();
         }
     }
-    else
-    {
-        mtCOVERAGE_TEST_MARKER();
-    }
+    taskEXIT_CRITICAL();
 }
 /*-----------------------------------------------------------*/
 

--- a/tasks.c
+++ b/tasks.c
@@ -1360,7 +1360,9 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
     {
         uxCurrentNumberOfTasks++;
 
-        if( xSchedulerRunning == pdFALSE )
+        #if ( configNUM_CORES > 1 )
+            if( xSchedulerRunning == pdFALSE )
+        #endif
         {
             if( uxCurrentNumberOfTasks == ( UBaseType_t ) 1 )
             {
@@ -1383,13 +1385,16 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                 }
                 else
                 {
-                    if( pxCurrentTCB->uxPriority <= pxNewTCB->uxPriority )
+                    if( xSchedulerRunning == pdFALSE )
                     {
-                        pxCurrentTCB = pxNewTCB;
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
+                        if( pxCurrentTCB->uxPriority <= pxNewTCB->uxPriority )
+                        {
+                            pxCurrentTCB = pxNewTCB;
+                        }
+                        else
+                        {
+                            mtCOVERAGE_TEST_MARKER();
+                        }
                     }
                 }
             #else


### PR DESCRIPTION
Merge prvAddNewTaskToReadyList from SMP

Description
-----------
* Merge prvAddNewTaskToReadyList from SMP

We should prohibit suspending idle task.
consider the following snippet
```C
static void prvFreshTask( void *pvParameters )
{
    TaskHandle_t idleTaskHandle;
    for(;;)
    {
        printf( "Hi Fresh\r\n" );
        vTaskDelay( pdMS_TO_TICKS( 1000 ) );

        /* Suspend the Idle Task. */
        idleTaskHandle = xTaskGetIdleTaskHandle();
        vTaskSuspend( idleTaskHandle );
    }
}

int main_fresh( void )
{
    xTaskCreate( prvFreshTask, "Check", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY, NULL );

	/* Start the scheduler itself. */
	vTaskStartScheduler();

    return 0;
}
```

There will be assert in 
```C
vTaskSwitchContext()
-> taskSELECT_HIGHEST_PRIORITY_TASK()
->configASSERT( listCURRENT_LIST_LENGTH( &( pxReadyTasksLists[ uxTopPriority ] ) ) > 0 );
```

Test Steps
-----------
* Run RP2040 main full
* Run WIN32-MSVC main full
* Compile RP2040 SMP main full

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
