### PR TITLE
Merge vTaskDelete from SMP

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -1505,6 +1505,9 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
              * not return. */
             uxTaskNumber++;
 
+            /* If the task is running (or yielding), we must add it to the
+             * termination list so that an idle task can delete it when it is
+             * no longer running. */
             if( taskTASK_IS_RUNNING( pxTCB ) || taskTASK_IS_YIELDING( pxTCB ) )
             {
                 /* A running task is being deleted.  This cannot complete within the
@@ -1540,30 +1543,38 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                 prvResetNextTaskUnblockTime();
             }
         }
+        taskEXIT_CRITICAL();
 
         /* If the task is not deleting itself, call prvDeleteTCB from outside of
          * critical section. If a task deletes itself, prvDeleteTCB is called
          * from prvCheckTasksWaitingTermination which is called from Idle task. */
-        if( pxTCB != pxCurrentTCB )
+        if( ( taskTASK_IS_RUNNING( pxTCB ) == pdFALSE ) && ( taskTASK_IS_YIELDING( pxTCB ) == pdFALSE ) )
         {
             prvDeleteTCB( pxTCB );
         }
 
         /* Force a reschedule if the task that has just been deleted was running. */
-        if( xSchedulerRunning != pdFALSE )
+        if( ( xSchedulerRunning != pdFALSE ) && ( taskTASK_IS_RUNNING( pxTCB ) ) )
         {
-            if( taskTASK_IS_RUNNING( pxTCB ) )
-            {
+            #if ( configNUM_CORES == 1 )
                 configASSERT( uxSchedulerSuspended == 0 );
-                prvYieldCore( xTaskRunningOnCore );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
+                portYIELD_WITHIN_API();
+            #else
+                taskENTER_CRITICAL();
+                {
+                    if( xTaskRunningOnCore == portGET_CORE_ID() )
+                    {
+                        configASSERT( uxSchedulerSuspended == 0 );
+                        vTaskYieldWithinAPI();
+                    }
+                    else
+                    {
+                        prvYieldCore( xTaskRunningOnCore );
+                    }
+                }
+                taskEXIT_CRITICAL();
+            #endif
         }
-        taskEXIT_CRITICAL();
     }
 
 #endif /* INCLUDE_vTaskDelete */

--- a/tasks.c
+++ b/tasks.c
@@ -1473,6 +1473,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
     {
         TCB_t * pxTCB;
         TaskRunning_t xTaskRunningOnCore;
+        BaseType_T xAddTaskToWaitingTermination = pdFALSE;
 
         taskENTER_CRITICAL();
         {
@@ -1523,6 +1524,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                  * check the termination list and free up any memory allocated by
                  * the scheduler for the TCB and stack of the deleted task. */
                 vListInsertEnd( &xTasksWaitingTermination, &( pxTCB->xStateListItem ) );
+                xAddTaskToWaitingTermination = pdTRUE;
 
                 /* Increment the ucTasksDeleted variable so the idle task knows
                  * there is a task that has been deleted and that it should therefore
@@ -1554,8 +1556,12 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
 
         /* If the task is not deleting itself, call prvDeleteTCB from outside of
          * critical section. If a task deletes itself, prvDeleteTCB is called
-         * from prvCheckTasksWaitingTermination which is called from Idle task. */
-        if( ( taskTASK_IS_RUNNING( pxTCB ) == pdFALSE ) && ( taskTASK_IS_YIELDING( pxTCB ) == pdFALSE ) )
+         * from prvCheckTasksWaitingTermination which is called from Idle task.
+         *
+         * xAddTaskToWaitingTermination checks the situation that the task to be deleted
+         * running on the other core is switched out.
+         */
+        if( xAddTaskToWaitingTermination == pdFALSE )
         {
             prvDeleteTCB( pxTCB );
         }

--- a/tasks.c
+++ b/tasks.c
@@ -1473,7 +1473,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
     {
         TCB_t * pxTCB;
         TaskRunning_t xTaskRunningOnCore;
-        BaseType_T xAddTaskToWaitingTermination = pdFALSE;
+        BaseType_t xAddTaskToWaitingTermination = pdFALSE;
 
         taskENTER_CRITICAL();
         {

--- a/tasks.c
+++ b/tasks.c
@@ -1473,7 +1473,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
     {
         TCB_t * pxTCB;
         TaskRunning_t xTaskRunningOnCore;
-        BaseType_t xAddTaskToWaitingTermination = pdFALSE;
+        BaseType_T xAddTaskToWaitingTermination = pdFALSE;
 
         taskENTER_CRITICAL();
         {

--- a/tasks.c
+++ b/tasks.c
@@ -1473,7 +1473,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
     {
         TCB_t * pxTCB;
         TaskRunning_t xTaskRunningOnCore;
-        BaseType_T xAddTaskToWaitingTermination = pdFALSE;
 
         taskENTER_CRITICAL();
         {
@@ -1524,7 +1523,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                  * check the termination list and free up any memory allocated by
                  * the scheduler for the TCB and stack of the deleted task. */
                 vListInsertEnd( &xTasksWaitingTermination, &( pxTCB->xStateListItem ) );
-                xAddTaskToWaitingTermination = pdTRUE;
 
                 /* Increment the ucTasksDeleted variable so the idle task knows
                  * there is a task that has been deleted and that it should therefore
@@ -1556,12 +1554,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
 
         /* If the task is not deleting itself, call prvDeleteTCB from outside of
          * critical section. If a task deletes itself, prvDeleteTCB is called
-         * from prvCheckTasksWaitingTermination which is called from Idle task.
-         *
-         * xAddTaskToWaitingTermination checks the situation that the task to be deleted
-         * running on the other core is switched out.
-         */
-        if( xAddTaskToWaitingTermination == pdFALSE )
+         * from prvCheckTasksWaitingTermination which is called from Idle task. */
+        if( ( taskTASK_IS_RUNNING( pxTCB ) == pdFALSE ) && ( taskTASK_IS_YIELDING( pxTCB ) == pdFALSE ) )
         {
             prvDeleteTCB( pxTCB );
         }

--- a/tasks.c
+++ b/tasks.c
@@ -1550,7 +1550,9 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                 prvResetNextTaskUnblockTime();
             }
         }
-        taskEXIT_CRITICAL();
+        #if ( configNUM_CORES == 1 )
+            taskEXIT_CRITICAL();
+        #endif
 
         /* If the task is not deleting itself, call prvDeleteTCB from outside of
          * critical section. If a task deletes itself, prvDeleteTCB is called
@@ -1567,7 +1569,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                 configASSERT( uxSchedulerSuspended == 0 );
                 portYIELD_WITHIN_API();
             #else
-                taskENTER_CRITICAL();
                 {
                     if( xTaskRunningOnCore == portGET_CORE_ID() )
                     {
@@ -1579,9 +1580,12 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                         prvYieldCore( xTaskRunningOnCore );
                     }
                 }
-                taskEXIT_CRITICAL();
             #endif
         }
+
+        #if ( configNUM_CORES > 1 )
+            taskEXIT_CRITICAL();
+        #endif
     }
 
 #endif /* INCLUDE_vTaskDelete */


### PR DESCRIPTION
Merge vTaskDelete from SMP

Description
-----------
* Add prvYeildCore for single core to reduce multicore macros
* Add taskTASK_IS_RUNNING for single core
* Add taskTASK_IS_YIELDING

Test Steps
-----------
* Run main full RP2040
* Run main full WIN32-MSVC
* Compile main full SMP RP2040

Related Issue
-----------
<!-- If any, please provide issue ID. -->

Performance Comparison Test
-----------
* Compared with smp-dev-vTaskSwtichContext branch
* Performance has only tiny differences with ( -O0 )

|                                                  | smp-dev-xTaskDelete ( -O0 ) |
| ------------------------------------------------ | ------------------- |
| PerfTest\_vTaskStartScheduler                    | 3                   |
| PerfTest\_vTaskDelete\_DeleteCurrentTask         | 4                   |
| PerfTest\_vTaskDelete\_DeleteOtherTask           | 2                   |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskHigh     | 0                   |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskLow      | 1                   |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskHigh   | 0                   |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskLow    | 0                   |
| PerfTest\_vTaskPrioritySet\_TaskSwitch           | 0                   |
| PerfTest\_vTaskSuspend\_SuspendCurrent           | 0                   |
| PerfTest\_vTaskSuspend\_SuspendOther             | 0                   |
| PerfTest\_vTaskSuspend\_TaskSwitch               | 0                   |
| PerfTest\_vTaskResume\_ResumeLowTask             | 0                   |
| PerfTest\_vTaskResume\_ResumeHighTask            | 0                   |
| PerfTest\_xTaskResumeFromISR\_ResumeLowTask      | 0                   |
| PerfTest\_xTaskResumeFromISR\_ResumeHighTask     | 0                   |
| PerfTest\_xTaskResumeFromISR\_TaskSwitch         | 0                   |
| PerfTest\_xTaskAbortDelay\_HighPriorityTask      | 0                   |
| PerfTest\_xTaskAbortDelay\_LowPriorityTask       | \-1                 |
| PerfTest\_xTaskAbortDelay\_TaskSwitch            | 0                   |
| PerfTest\_xTaskIncrementTick\_SchedulerSuspended | 0                   |
| PerfTest\_xTaskIncrementTick\_SchedulerRunning   | 0                   |
| PerfTest\_xTaskIncrementTick\_TaskSwitch         | 0                   |
| PerfTest\_vTaskSwtichContext\_SwitchToCurrent    | 0                   |
| PerfTest\_vTaskSwtichContext\_SwitchToOther      | 1                   |
| PerfTest\_vTaskSwtichContext\_TaskSwitch         | 0                   |
| PerfTest\_xQueueSend\_UnblockHighTask            | 0                   |
| PerfTest\_xQueueSend\_UnblockLowTask             | 0                   |
| PerfTest\_xQueueSend\_TaskSwitch                 | \-1                 |
| PerfTest\_xEventGroupsSetBits\_unblockHighTask   | 0                   |
| PerfTest\_xEventGroupsSetBits\_unblockLowTask    | 0                   |
| PerfTest\_xEventGroupSetBits\_TaskSwitch         | 0                   |
| PerfTest\_xTaskNotifyGive\_UnblockHighTask       | 0                   |
| PerfTest\_xTaskNotifyGive\_UnblockLowTask        | \-4                 |
| PerfTest\_xTaskNotifyGive\_TaskSwitch            | 0                   |
| PerfTest\_xTaskNotifyFromISR\_NotifyHighTask     | 0                   |
| PerfTest\_xTaskNotifyFromISR\_NotifyLowTask      | 0                   |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyHighTask | 0                   |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyLowTask  | 0                   |
| xAvailableHeapSpaceInBytes                       | 0                   |
| xNumberOfSuccessfulAllocations                   | 0                   |
| xNumberOfSuccessfulFrees                         | 0                   |
| xMinimumEverFreeBytesRemaining                   | 0                   |
| text                                             | 0                   |
| data                                             | 0                   |
| bss                                              | 0                   |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
