### PR TITLE
Merge vTaskSuspend from SMP

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2086,17 +2086,12 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
             }
             #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
         }
-        taskEXIT_CRITICAL();
 
         if( xSchedulerRunning != pdFALSE )
         {
             /* Reset the next expected unblock time in case it referred to the
              * task that is now in the Suspended state. */
-            taskENTER_CRITICAL();
-            {
-                prvResetNextTaskUnblockTime();
-            }
-            taskEXIT_CRITICAL();
+            prvResetNextTaskUnblockTime();
         }
         else
         {
@@ -2107,17 +2102,22 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
         {
             if( xSchedulerRunning != pdFALSE )
             {
-                /* The current task has just been suspended. */
-                configASSERT( uxSchedulerSuspended == 0 );
-
-                taskENTER_CRITICAL();
+                if( xTaskRunningOnCore == portGET_CORE_ID() )
+                {
+                    /* The current task has just been suspended. */
+                    configASSERT( uxSchedulerSuspended == 0 );
+                    vTaskYieldWithinAPI();
+                }
+                else
                 {
                     prvYieldCore( xTaskRunningOnCore );
                 }
+
                 taskEXIT_CRITICAL();
             }
             else
             {
+                taskEXIT_CRITICAL();
                 #if ( configNUM_CORES == 1 )
                     /* The scheduler is not running, but the task that was pointed
                      * to by pxCurrentTCB has just been suspended and pxCurrentTCB
@@ -2163,7 +2163,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
         }
         else
         {
-            mtCOVERAGE_TEST_MARKER();
+            taskEXIT_CRITICAL();
         }
     }
 

--- a/tasks.c
+++ b/tasks.c
@@ -2128,7 +2128,11 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                 {
                     /* The current task has just been suspended. */
                     configASSERT( uxSchedulerSuspended == 0 );
-                    vTaskYieldWithinAPI();
+                    #if ( portCRITICAL_NESTING_IN_TCB == 1 )
+                        vTaskYieldWithinAPI();
+                    #else
+                        portYIELD_WITHIN_API();
+                    #endif
                 }
                 else
                 {


### PR DESCRIPTION
Merge vTaskSuspend from SMP

Description
-----------
Merge vTaskSuspend from SMP

Test Steps
-----------
* Run main full on RP2040
* Run main full on WIN32-MSVC
* Compile main full SMP on RP2040

Related Issue
-----------
<!-- If any, please provide issue ID. -->

Performance Comparison Test
-----------
* Compared with smp-dev-xTaskDelete
* The performance increases due to the removing of some tskENTER_CRITICAL and tskEXIT_CRITICAL calls. The code in critical section is increased but the performance is better.

|                                                  | smp-dev-vTaskSuspend ( -O0 ) | smp-dev-vTaskSuspend ( -Ofast ) |
| ------------------------------------------------ | -------------------- | -------------------- |
| PerfTest\_vTaskStartScheduler                    | 0                    | 0                    |
| PerfTest\_vTaskDelete\_DeleteCurrentTask         | 0                    | 0                    |
| PerfTest\_vTaskDelete\_DeleteOtherTask           | 0                    | 0                    |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskHigh     | 0                    | 0                    |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskLow      | 0                    | 0                    |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskHigh   | 1                    | 0                    |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskLow    | 0                    | 0                    |
| PerfTest\_vTaskPrioritySet\_TaskSwitch           | 0                    | 0                    |
| PerfTest\_vTaskSuspend\_SuspendCurrent           | \-67                 | \-46                 |
| PerfTest\_vTaskSuspend\_SuspendOther             | \-77                 | \-58                 |
| PerfTest\_vTaskSuspend\_TaskSwitch               | \-59                 | \-59                 |
| PerfTest\_vTaskResume\_ResumeLowTask             | 0                    | 0                    |
| PerfTest\_vTaskResume\_ResumeHighTask            | 8                    | \-14                 |
| PerfTest\_xTaskResumeFromISR\_ResumeLowTask      | 0                    | 0                    |
| PerfTest\_xTaskResumeFromISR\_ResumeHighTask     | 8                    | \-14                 |
| PerfTest\_xTaskResumeFromISR\_TaskSwitch         | \-59                 | \-61                 |
| PerfTest\_xTaskAbortDelay\_HighPriorityTask      | 0                    | 0                    |
| PerfTest\_xTaskAbortDelay\_LowPriorityTask       | 1                    | 0                    |
| PerfTest\_xTaskAbortDelay\_TaskSwitch            | 0                    | 0                    |
| PerfTest\_xTaskIncrementTick\_SchedulerSuspended | 0                    | 0                    |
| PerfTest\_xTaskIncrementTick\_SchedulerRunning   | 0                    | 0                    |
| PerfTest\_xTaskIncrementTick\_TaskSwitch         | 0                    | 0                    |
| PerfTest\_vTaskSwtichContext\_SwitchToCurrent    | 0                    | 0                    |
| PerfTest\_vTaskSwtichContext\_SwitchToOther      | 0                    | 0                    |
| PerfTest\_vTaskSwtichContext\_TaskSwitch         | 0                    | 0                    |
| PerfTest\_xQueueSend\_UnblockHighTask            | 0                    | 0                    |
| PerfTest\_xQueueSend\_UnblockLowTask             | 0                    | 0                    |
| PerfTest\_xQueueSend\_TaskSwitch                 | 1                    | 0                    |
| PerfTest\_xEventGroupsSetBits\_unblockHighTask   | 0                    | 0                    |
| PerfTest\_xEventGroupsSetBits\_unblockLowTask    | 0                    | 0                    |
| PerfTest\_xEventGroupSetBits\_TaskSwitch         | 0                    | 0                    |
| PerfTest\_xTaskNotifyGive\_UnblockHighTask       | 0                    | 0                    |
| PerfTest\_xTaskNotifyGive\_UnblockLowTask        | 4                    | 0                    |
| PerfTest\_xTaskNotifyGive\_TaskSwitch            | 0                    | 0                    |
| PerfTest\_xTaskNotifyFromISR\_NotifyHighTask     | 0                    | 0                    |
| PerfTest\_xTaskNotifyFromISR\_NotifyLowTask      | 0                    | 0                    |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyHighTask | 0                    | 0                    |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyLowTask  | 0                    | 0                    |
| xAvailableHeapSpaceInBytes                       | 0                    | 0                    |
| xNumberOfSuccessfulAllocations                   | 0                    | 0                    |
| xNumberOfSuccessfulFrees                         | 0                    | 0                    |
| xMinimumEverFreeBytesRemaining                   | 0                    | 0                    |
| text                                             | 64                   | 16                   |
| data                                             | 0                    | 0                    |
| bss                                              | 0                    | 0                    |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
