### PR TITLE
Update eTaskGetState for SMP

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -1789,12 +1789,14 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
 
         configASSERT( pxTCB );
 
-        if( taskTASK_IS_RUNNING( pxTCB ) )
-        {
-            /* The task calling this function is querying its own state. */
-            eReturn = eRunning;
-        }
-        else
+        #if ( configNUM_CORES == 1 )
+            if( taskTASK_IS_RUNNING( pxTCB ) )
+            {
+                /* The task calling this function is querying its own state. */
+                eReturn = eRunning;
+            }
+            else
+        #endif
         {
             taskENTER_CRITICAL();
             {
@@ -1866,7 +1868,17 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
             {
                 /* If the task is not in any other state, it must be in the
                  * Ready (including pending ready) state. */
-                eReturn = eReady;
+                #if ( configNUM_CORES > 1 )
+                    if( taskTASK_IS_RUNNING( pxTCB ) )
+                    {
+                        /* Is it actively running on a core? */
+                        eReturn = eRunning;
+                    }
+                    else
+                #endif
+                {
+                    eReturn = eReady;
+                }
             }
         }
 


### PR DESCRIPTION
Update eTaskGetState for SMP

Description
-----------
SMP task state is different from single core

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->

Performance Comparison Test
-----------
* SMP only PR. No performance difference.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
