### PR TITLE
Remove unnecessary loop in xTaskIncrementTick for single core

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3978,10 +3978,10 @@ BaseType_t xTaskIncrementTick( void )
     TickType_t xItemValue;
     BaseType_t xSwitchRequired = pdFALSE;
 
-    #if ( configUSE_PREEMPTION == 1 )
+    #if ( configUSE_PREEMPTION == 1 ) && ( configNUM_CORES > 1 )
         UBaseType_t x;
         BaseType_t xYieldRequiredForCore[ configNUM_CORES ] = { pdFALSE };
-    #endif /* #if ( configUSE_PREEMPTION == 1 ) */
+    #endif /* #if ( configUSE_PREEMPTION == 1 ) && ( configNUM_CORES > 1 ) */
 
     #if ( configNUM_CORES > 1 )
         taskENTER_CRITICAL();
@@ -4156,22 +4156,10 @@ BaseType_t xTaskIncrementTick( void )
 
             #if ( configUSE_PREEMPTION == 1 )
             {
-                for( x = ( UBaseType_t ) 0; x < ( UBaseType_t ) configNUM_CORES; x++ )
-                {
-                    if( xYieldPendings[ x ] != pdFALSE )
-                    {
-                        xYieldRequiredForCore[ x ] = pdTRUE;
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
-                }
-
                 #if ( configNUM_CORES == 1 )
                 {
                     /* For single core the core ID is always 0. */
-                    if( xYieldRequiredForCore[ 0 ] != pdFALSE )
+                    if( xYieldPendings[ 0 ] != pdFALSE )
                     {
                         xSwitchRequired = pdTRUE;
                     }
@@ -4184,6 +4172,18 @@ BaseType_t xTaskIncrementTick( void )
                 {
                     BaseType_t xCoreID;
                     xCoreID = portGET_CORE_ID();
+
+                    for( x = ( UBaseType_t ) 0; x < ( UBaseType_t ) configNUM_CORES; x++ )
+                    {
+                        if( xYieldPendings[ x ] != pdFALSE )
+                        {
+                            xYieldRequiredForCore[ x ] = pdTRUE;
+                        }
+                        else
+                        {
+                            mtCOVERAGE_TEST_MARKER();
+                        }
+                    }
 
                     for( x = ( UBaseType_t ) 0; x < ( UBaseType_t ) configNUM_CORES; x++ )
                     {

--- a/tasks.c
+++ b/tasks.c
@@ -4175,23 +4175,11 @@ BaseType_t xTaskIncrementTick( void )
 
                     for( x = ( UBaseType_t ) 0; x < ( UBaseType_t ) configNUM_CORES; x++ )
                     {
-                        if( xYieldPendings[ x ] != pdFALSE )
-                        {
-                            xYieldRequiredForCore[ x ] = pdTRUE;
-                        }
-                        else
-                        {
-                            mtCOVERAGE_TEST_MARKER();
-                        }
-                    }
-
-                    for( x = ( UBaseType_t ) 0; x < ( UBaseType_t ) configNUM_CORES; x++ )
-                    {
                         #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
                             if( pxCurrentTCBs[ x ]->xPreemptionDisable == pdFALSE )
                         #endif
                         {
-                            if( xYieldRequiredForCore[ x ] != pdFALSE )
+                            if( ( xYieldRequiredForCore[ x ] != pdFALSE ) || ( xYieldPendings[ x ] != pdFALSE ) )
                             {
                                 if( x == ( UBaseType_t ) xCoreID )
                                 {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
With this PR the PerfTest_xTaskIncrementTick_SchedulerRunning is reduce from 46 to 0 with ( -O0 ) optimization.

|                                                  | smp-integration ( -O0 ) | fix-xTaskIncrementTick-for-single-core ( -O0 ) | smp-integration ( -Ofast ) | fix-xTaskIncrementTick-for-single-core ( -Ofast ) |
| ------------------------------------------------ | ----------------------- | ---------------------------------------------- | -------------------------- | ------------------------------------------------- |
| PerfTest\_vTaskStartScheduler                    | 89907                   | 361                                            | 86551                      | 14                                                |
| PerfTest\_vTaskDelete\_DeleteCurrentTask         | 700                     | 0                                              | 476                        | 0                                                 |
| PerfTest\_vTaskDelete\_DeleteOtherTask           | 1265                    | 16                                             | 772                        | 0                                                 |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskHigh     | 715                     | 0                                              | 438                        | 0                                                 |
| PerfTest\_vTaskPrioritySet\_SetOtherTaskLow      | 439                     | 0                                              | 219                        | 0                                                 |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskHigh   | 466                     | 0                                              | 257                        | 0                                                 |
| PerfTest\_vTaskPrioritySet\_SetCurrentTaskLow    | 748                     | \-1                                            | 473                        | 0                                                 |
| PerfTest\_vTaskPrioritySet\_TaskSwitch           | 3294                    | 0                                              | 1865                       | 0                                                 |
| PerfTest\_vTaskSuspend\_SuspendCurrent           | 809                     | 0                                              | 530                        | 0                                                 |
| PerfTest\_vTaskSuspend\_SuspendOther             | 524                     | 0                                              | 299                        | 0                                                 |
| PerfTest\_vTaskSuspend\_TaskSwitch               | 1466                    | 0                                              | 909                        | 0                                                 |
| PerfTest\_vTaskResume\_ResumeLowTask             | 419                     | 0                                              | 205                        | 0                                                 |
| PerfTest\_vTaskResume\_ResumeHighTask            | 663                     | 0                                              | 410                        | 0                                                 |
| PerfTest\_xTaskResumeFromISR\_ResumeLowTask      | 485                     | 0                                              | 217                        | 0                                                 |
| PerfTest\_xTaskResumeFromISR\_ResumeHighTask     | 802                     | 0                                              | 432                        | 0                                                 |
| PerfTest\_xTaskResumeFromISR\_TaskSwitch         | 1740                    | 0                                              | 1006                       | 0                                                 |
| PerfTest\_xTaskAbortDelay\_HighPriorityTask      | 966                     | 8                                              | 603                        | 0                                                 |
| PerfTest\_xTaskAbortDelay\_LowPriorityTask       | 726                     | 8                                              | 430                        | 0                                                 |
| PerfTest\_xTaskAbortDelay\_TaskSwitch            | 1831                    | 16                                             | 1158                       | 0                                                 |
| PerfTest\_xTaskIncrementTick\_SchedulerSuspended | 61                      | 0                                              | 34                         | 0                                                 |
| PerfTest\_xTaskIncrementTick\_SchedulerRunning   | 127                     | 0                                              | 117                        | 0                                                 |
| PerfTest\_xTaskIncrementTick\_TaskSwitch         | 119942                  | 1                                              | 119958                     | 0                                                 |
| PerfTest\_vTaskSwtichContext\_SwitchToCurrent    | 271                     | 0                                              | 191                        | 0                                                 |
| PerfTest\_vTaskSwtichContext\_SwitchToOther      | 260                     | \-1                                            | 189                        | 0                                                 |
| PerfTest\_vTaskSwtichContext\_TaskSwitch         | 528                     | 2                                              | 381                        | 0                                                 |
| PerfTest\_xQueueSend\_UnblockHighTask            | 1118                    | 0                                              | 680                        | 0                                                 |
| PerfTest\_xQueueSend\_UnblockLowTask             | 616                     | 0                                              | 350                        | 0                                                 |
| PerfTest\_xQueueSend\_TaskSwitch                 | 2837                    | 8                                              | 1690                       | 0                                                 |
| PerfTest\_xEventGroupsSetBits\_unblockHighTask   | 953                     | 8                                              | 596                        | 0                                                 |
| PerfTest\_xEventGroupsSetBits\_unblockLowTask    | 656                     | 9                                              | 384                        | 0                                                 |
| PerfTest\_xEventGroupSetBits\_TaskSwitch         | 1985                    | 16                                             | 1233                       | 0                                                 |
| PerfTest\_xTaskNotifyGive\_UnblockHighTask       | 775                     | 0                                              | 486                        | 0                                                 |
| PerfTest\_xTaskNotifyGive\_UnblockLowTask        | 1464                    | 1                                              | 941                        | \-1                                               |
| PerfTest\_xTaskNotifyGive\_TaskSwitch            | 1469                    | 0                                              | 946                        | 0                                                 |
| PerfTest\_xTaskNotifyFromISR\_NotifyHighTask     | 966                     | 0                                              | 544                        | 0                                                 |
| PerfTest\_xTaskNotifyFromISR\_NotifyLowTask      | 477                     | 0                                              | 224                        | 0                                                 |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyHighTask | 889                     | 0                                              | 495                        | 0                                                 |
| PerfTest\_vTaskNotifyGiveFromISR\_NotifyLowTask  | 427                     | 0                                              | 203                        | 0                                                 |
| xAvailableHeapSpaceInBytes                       | 515976                  | 0                                              | 515976                     | 0                                                 |
| xNumberOfSuccessfulAllocations                   | 55408                   | 0                                              | 55408                      | 0                                                 |
| xNumberOfSuccessfulFrees                         | 55406                   | 0                                              | 55406                      | 0                                                 |
| xMinimumEverFreeBytesRemaining                   | 499368                  | 0                                              | 499368                     | 0                                                 |
| text                                             | 58584                   | 160                                            | 42548                      | 48                                                |
| data                                             | 128                     | 0                                              | 128                        | 0                                                 |
| bss                                              | 536276                  | 0                                              | 536272                     | 0                                                 |

Test Steps
-----------
RP2040 SMP soaked test
SMP unit test

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
