### PR TITLE
Remove builtin clz in prvSelectHighestPriorityTask

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -352,6 +352,10 @@
     #define configNUM_CORES    1
 #endif
 
+#if ( configNUM_CORES > 32 )
+    #error Maximum supported configNUM_CORES is 32
+#endif
+
 #ifndef configRUN_MULTIPLE_PRIORITIES
     #define configRUN_MULTIPLE_PRIORITIES    0
 #endif

--- a/tasks.c
+++ b/tasks.c
@@ -1022,6 +1022,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                     UBaseType_t uxCoreMap = pxPreviousTCB->uxCoreAffinityMask;
                     BaseType_t xLowestPriority = pxPreviousTCB->uxPriority;
                     BaseType_t xLowestPriorityCore = -1;
+                    BaseType_t x;
 
                     if( ( pxPreviousTCB->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0 )
                     {
@@ -1044,33 +1045,33 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
                     uxCoreMap &= ( ( 1 << configNUM_CORES ) - 1 );
 
-                    while( uxCoreMap != 0 )
+                    for( x = configNUM_CORES; x >= 0; x-- )
                     {
-                        uint32_t uxCore;
+                        UBaseType_t uxCore = ( UBaseType_t ) x;
                         BaseType_t xTaskPriority;
 
-                        uxCore = 31UL - ( uint32_t ) __builtin_clz( uxCoreMap );
-                        configASSERT( taskVALID_CORE_ID( uxCore ) );
-
-                        xTaskPriority = ( BaseType_t ) pxCurrentTCBs[ uxCore ]->uxPriority;
-
-                        if( ( pxCurrentTCBs[ uxCore ]->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0 )
+                        if( ( uxCoreMap & ( 1 << uxCore ) ) != 0 )
                         {
-                            xTaskPriority = xTaskPriority - ( BaseType_t ) 1;
-                        }
+                            xTaskPriority = ( BaseType_t ) pxCurrentTCBs[ uxCore ]->uxPriority;
 
-                        uxCoreMap &= ~( 1 << uxCore );
-
-                        if( ( xTaskPriority < xLowestPriority ) &&
-                            ( taskTASK_IS_RUNNING( pxCurrentTCBs[ uxCore ] ) != pdFALSE ) &&
-                            ( xYieldPendings[ uxCore ] == pdFALSE ) )
-                        {
-                            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == pdFALSE )
-                            #endif
+                            if( ( pxCurrentTCBs[ uxCore ]->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0 )
                             {
-                                xLowestPriority = xTaskPriority;
-                                xLowestPriorityCore = uxCore;
+                                xTaskPriority = xTaskPriority - ( BaseType_t ) 1;
+                            }
+
+                            uxCoreMap &= ~( 1 << uxCore );
+
+                            if( ( xTaskPriority < xLowestPriority ) &&
+                                ( taskTASK_IS_RUNNING( pxCurrentTCBs[ uxCore ] ) != pdFALSE ) &&
+                                ( xYieldPendings[ uxCore ] == pdFALSE ) )
+                            {
+                                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                                    if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == pdFALSE )
+                                #endif
+                                {
+                                    xLowestPriority = xTaskPriority;
+                                    xLowestPriorityCore = uxCore;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Remove builtin clz in prvSelectHighestPriorityTask

Description
-----------
__builtin_clz is compiler specific API should not be used in common code. This PR remove the usage of __builtin_clz.
We can have port optimization in another PR

Run RP2040 SMP demo with core affinity enabled.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
