### PR TITLE
Remove SMP portCRITICAL_NESTING_IN_TCB dependency

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1532,6 +1532,7 @@ prvinitialisenewtimer
 prvinsertblockintofreelist
 prvlockqueue
 prvnotifyqueuesetcontainer
+prvminimalidletask
 prvportmalloc
 prvportresetpic
 prvprocesssimulatedinterrupts
@@ -2455,6 +2456,7 @@ uxsemaphoregetcount
 uxsemaphoregetcountfromisr
 uxstate
 uxstreambuffernumber
+uxtaskattributes
 uxtaskgetnumberoftasks
 uxtaskgetstackhighwatermark
 uxtaskgetsystemstate
@@ -2826,6 +2828,7 @@ xlist
 xlistend
 xlowestpriority
 xlowestprioritycore
+xlowestprioritytopreempt
 xmair
 xmaxcount
 xmaxexpirycountbeforestopping

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -356,12 +356,6 @@
     #define configRUN_MULTIPLE_PRIORITIES    0
 #endif
 
-#if ( configNUM_CORES > 1 )
-    #if portCRITICAL_NESTING_IN_TCB == 0
-        #error portCRITICAL_NESTING_IN_TCB is required in SMP
-    #endif
-#endif
-
 #ifndef portGET_CORE_ID
 
     #if ( configNUM_CORES == 1 )

--- a/include/task.h
+++ b/include/task.h
@@ -203,7 +203,7 @@ typedef enum
  * \defgroup taskYIELD taskYIELD
  * \ingroup SchedulerControl
  */
-#define taskYIELD()                        portYIELD()
+#define taskYIELD()    portYIELD()
 
 /**
  * task. h
@@ -217,8 +217,13 @@ typedef enum
  * \defgroup taskENTER_CRITICAL taskENTER_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskENTER_CRITICAL()               portENTER_CRITICAL()
-#define taskENTER_CRITICAL_FROM_ISR()      portSET_INTERRUPT_MASK_FROM_ISR()
+#if ( configNUM_CORES == 1 )
+    #define taskENTER_CRITICAL()    portENTER_CRITICAL()
+#else
+    void vSmpTaskEnterCritical( void );
+    #define taskENTER_CRITICAL    vSmpTaskEnterCritical
+#endif
+#define taskENTER_CRITICAL_FROM_ISR()    portSET_INTERRUPT_MASK_FROM_ISR()
 
 /**
  * task. h
@@ -232,7 +237,12 @@ typedef enum
  * \defgroup taskEXIT_CRITICAL taskEXIT_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskEXIT_CRITICAL()                portEXIT_CRITICAL()
+#if ( configNUM_CORES == 1 )
+    #define taskEXIT_CRITICAL()    portEXIT_CRITICAL()
+#else
+    void vSmpTaskExitCritical( void );
+    #define taskEXIT_CRITICAL    vSmpTaskExitCritical
+#endif
 #define taskEXIT_CRITICAL_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
 
 /**


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR removes the portCRITICAL_NESTING_IN_TCB constraint in SMP.

The problems are the following variables in kernel are private:
1. critical nesting count : prvCheckForRunStateChanged needs this variable to decide if the task just entering the critical section or suspending the scheduler
2. xTaskRunState in TCB : prvCheckForRunStateChanged needs this variable to know if this task is requested to yield when it disable the interrupt and trying to acquire the lock
3. xYieldPendings : Task yields when leaving the critical section

This PR separates the behavior into porting and kernel.
The code need to access kernel variables is left in kernel. The porting only maintains it's own critical nesting count.

Porting export the macros to kernel 
```
#define portGET_CRITICAL_NESTING_COUNT()          ( uxCriticalNestings[ portGET_CORE_ID() ] )
```

Two functions are added for SMP in order to support critical nesting count in porting.
* vSmpTaskEnterCritical() : Task need to check run state change when just entering the critical section. If the run state changed to yield, the task need to exit the critical section and try to enter the critical section again.
* vSmpTaskExitCritical() : Task need to check xYieldPendings when leaving the critical section. If there is pending yield, the task need to yield immediately.

Test Steps
-----------
Run RP2040 demo with portCRITICAL_NESTING_IN_TCB = 0

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
