### PR TITLE
Yield for task when core affinity changed

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2522,7 +2522,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t * pxTCB;
         BaseType_t xCoreID;
         UBaseType_t uxPrevCoreAffinityMask;
-        #if( configUSE_PREEMPTION == 1 )
+
+        #if ( configUSE_PREEMPTION == 1 )
             UBaseType_t uxPrevNotAllowedCores;
         #endif
 
@@ -2548,7 +2549,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 }
                 else
                 {
-                    #if( configUSE_PREEMPTION == 1 )
+                    #if ( configUSE_PREEMPTION == 1 )
                     {
                         /* Calculate the cores on which this task was not allowed to
                          * run previously. */


### PR DESCRIPTION
Yield for task when core affinity changed

Description
-----------
If new cores are linked to this task, the task may be able to run now. Call prvYieldForTask function to check if this task can run on core.

Test Steps
-----------
Run SMP unit test.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
