### PR TITLE
Move critical nesting count to port

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -356,12 +356,6 @@
     #define configRUN_MULTIPLE_PRIORITIES    0
 #endif
 
-#if ( configNUM_CORES > 1 )
-    #if portCRITICAL_NESTING_IN_TCB == 0
-        #error portCRITICAL_NESTING_IN_TCB is required in SMP
-    #endif
-#endif
-
 #ifndef portGET_CORE_ID
 
     #if ( configNUM_CORES == 1 )

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -140,6 +140,15 @@
 
 /*-----------------------------------------------------------*/
 
+/* Critical nesting count management. */
+/* This port currently manages nesting count in TCB. */
+#define portCRITICAL_NESTING_IN_TCB             1
+#define portGET_CRITICAL_NESTING_COUNT()        ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting )
+#define portSET_CRITICAL_NESTING_COUNT( x )     ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting = x )
+#define portINCREMENT_CRITICAL_NESTING_COUNT()  ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting++ )
+#define portDECREMENT_CRITICAL_NESTING_COUNT()  ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting-- )
+/*-----------------------------------------------------------*/
+
 /* Critical section management. */
 
     #define portSET_INTERRUPT_MASK()                     ({               \

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -143,10 +143,7 @@
 /* Critical nesting count management. */
 /* This port currently manages nesting count in TCB. */
 #define portCRITICAL_NESTING_IN_TCB             1
-#define portGET_CRITICAL_NESTING_COUNT()        ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting )
-#define portSET_CRITICAL_NESTING_COUNT( x )     ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting = x )
-#define portINCREMENT_CRITICAL_NESTING_COUNT()  ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting++ )
-#define portDECREMENT_CRITICAL_NESTING_COUNT()  ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting-- )
+
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -141,16 +141,11 @@
 /*-----------------------------------------------------------*/
 
 /* Critical nesting count management. */
-/* This port supports to manage nesting count in port or TCB. */
-#define portCRITICAL_NESTING_IN_TCB             1
-
-#if ( portCRITICAL_NESTING_IN_TCB == 0 )
     extern UBaseType_t uxCriticalNestings[ configNUM_CORES ];
     #define portGET_CRITICAL_NESTING_COUNT()        ( uxCriticalNestings[ portGET_CORE_ID() ] )
     #define portSET_CRITICAL_NESTING_COUNT( x )     ( uxCriticalNestings[ portGET_CORE_ID() ] = ( x ) )
     #define portINCREMENT_CRITICAL_NESTING_COUNT()  ( uxCriticalNestings[ portGET_CORE_ID() ]++ )
     #define portDECREMENT_CRITICAL_NESTING_COUNT()  ( uxCriticalNestings[ portGET_CORE_ID() ]-- )
-#endif
 
 /*-----------------------------------------------------------*/
 

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -141,8 +141,16 @@
 /*-----------------------------------------------------------*/
 
 /* Critical nesting count management. */
-/* This port currently manages nesting count in TCB. */
+/* This port supports to manage nesting count in port or TCB. */
 #define portCRITICAL_NESTING_IN_TCB             1
+
+#if ( portCRITICAL_NESTING_IN_TCB == 0 )
+    extern UBaseType_t uxCriticalNestings[ configNUM_CORES ];
+    #define portGET_CRITICAL_NESTING_COUNT()        ( uxCriticalNestings[ portGET_CORE_ID() ] )
+    #define portSET_CRITICAL_NESTING_COUNT( x )     ( uxCriticalNestings[ portGET_CORE_ID() ] = ( x ) )
+    #define portINCREMENT_CRITICAL_NESTING_COUNT()  ( uxCriticalNestings[ portGET_CORE_ID() ]++ )
+    #define portDECREMENT_CRITICAL_NESTING_COUNT()  ( uxCriticalNestings[ portGET_CORE_ID() ]-- )
+#endif
 
 /*-----------------------------------------------------------*/
 

--- a/portable/ThirdParty/GCC/RP2040/port.c
+++ b/portable/ThirdParty/GCC/RP2040/port.c
@@ -117,13 +117,9 @@ static void prvTaskExitError( void );
  * to be called before the scheduler is started */
 #if ( configNUM_CORES == 1 )
     static UBaseType_t uxCriticalNesting;
-#else
-    /* Maintain the critical nesting count in port. */
-    #if ( portCRITICAL_NESTING_IN_TCB == 0 )
-        UBaseType_t uxCriticalNestings[ configNUM_CORES ] = { 0 };
-        BaseType_t xSchedulerStarted[ configNUM_CORES ] = { 0 };
-    #endif
-#endif
+#else /* #if ( configNUM_CORES == 1 ) */
+    UBaseType_t uxCriticalNestings[ configNUM_CORES ] = { 0 };
+#endif /* #if ( configNUM_CORES == 1 ) */
 
 /*-----------------------------------------------------------*/
 

--- a/tasks.c
+++ b/tasks.c
@@ -281,11 +281,11 @@ typedef BaseType_t TaskRunning_t;
 #define taskATTRIBUTE_IS_IDLE    ( UBaseType_t ) ( 1UL << 0UL )
 
 #if ( configNUM_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 )
-    #define portGET_CRITICAL_NESTING_COUNT()        ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting )
-    #define portSET_CRITICAL_NESTING_COUNT( x )     ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting = ( x ) )
-    #define portINCREMENT_CRITICAL_NESTING_COUNT()  ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting++ )
-    #define portDECREMENT_CRITICAL_NESTING_COUNT()  ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting-- )
-#endif  /* #if ( configNUM_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 ) */
+    #define portGET_CRITICAL_NESTING_COUNT()          ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting )
+    #define portSET_CRITICAL_NESTING_COUNT( x )       ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting = ( x ) )
+    #define portINCREMENT_CRITICAL_NESTING_COUNT()    ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting++ )
+    #define portDECREMENT_CRITICAL_NESTING_COUNT()    ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting-- )
+#endif /* #if ( configNUM_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 ) */
 
 /*
  * Task control block.  A task control block (TCB) is allocated for each task,
@@ -3067,12 +3067,12 @@ static BaseType_t prvCreateIdleTasks( void )
              * address of the RAM then create the idle task. */
             vApplicationGetIdleTaskMemory( &pxIdleTaskTCBBuffer, &pxIdleTaskStackBuffer, &ulIdleTaskStackSize );
             xIdleTaskHandles[ 0 ] = xTaskCreateStatic( prvIdleTask,
-                                                 configIDLE_TASK_NAME,
-                                                 ulIdleTaskStackSize,
-                                                 ( void * ) NULL,       /*lint !e961.  The cast is not redundant for all compilers. */
-                                                 portPRIVILEGE_BIT,     /* In effect ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), but tskIDLE_PRIORITY is zero. */
-                                                 pxIdleTaskStackBuffer,
-                                                 pxIdleTaskTCBBuffer ); /*lint !e961 MISRA exception, justified as it is not a redundant explicit cast to all supported compilers. */
+                                                       configIDLE_TASK_NAME,
+                                                       ulIdleTaskStackSize,
+                                                       ( void * ) NULL,       /*lint !e961.  The cast is not redundant for all compilers. */
+                                                       portPRIVILEGE_BIT,     /* In effect ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), but tskIDLE_PRIORITY is zero. */
+                                                       pxIdleTaskStackBuffer,
+                                                       pxIdleTaskTCBBuffer ); /*lint !e961 MISRA exception, justified as it is not a redundant explicit cast to all supported compilers. */
 
             if( xIdleTaskHandles[ 0 ] != NULL )
             {
@@ -3090,12 +3090,12 @@ static BaseType_t prvCreateIdleTasks( void )
                                    configIDLE_TASK_NAME,
                                    configMINIMAL_STACK_SIZE,
                                    ( void * ) NULL,
-                                   portPRIVILEGE_BIT,  /* In effect ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), but tskIDLE_PRIORITY is zero. */
+                                   portPRIVILEGE_BIT,        /* In effect ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), but tskIDLE_PRIORITY is zero. */
                                    &xIdleTaskHandles[ 0 ] ); /*lint !e961 MISRA exception, justified as it is not a redundant explicit cast to all supported compilers. */
         }
         #endif /* configSUPPORT_STATIC_ALLOCATION */
     }
-    #else
+    #else /* #if ( configNUM_CORES == 1 ) */
     {
         BaseType_t xCoreID;
         char cIdleName[ configMAX_TASK_NAME_LEN ];
@@ -3218,7 +3218,7 @@ static BaseType_t prvCreateIdleTasks( void )
             #endif /* configSUPPORT_STATIC_ALLOCATION */
         }
     }
-    #endif
+    #endif /* #if ( configNUM_CORES == 1 ) */
 
     return xReturn;
 }

--- a/tasks.c
+++ b/tasks.c
@@ -280,6 +280,13 @@ typedef BaseType_t TaskRunning_t;
 /* Indicates that the task is an Idle task. */
 #define taskATTRIBUTE_IS_IDLE    ( UBaseType_t ) ( 1UL << 0UL )
 
+#if ( configNUM_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 )
+    #define portGET_CRITICAL_NESTING_COUNT()        ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting )
+    #define portSET_CRITICAL_NESTING_COUNT( x )     ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting = ( x ) )
+    #define portINCREMENT_CRITICAL_NESTING_COUNT()  ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting++ )
+    #define portDECREMENT_CRITICAL_NESTING_COUNT()  ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting-- )
+#endif  /* #if ( configNUM_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 ) */
+
 /*
  * Task control block.  A task control block (TCB) is allocated for each task,
  * and stores task state information, including a pointer to the task's context

--- a/tasks.c
+++ b/tasks.c
@@ -6141,7 +6141,7 @@ static void prvResetNextTaskUnblockTime( void )
              * interrupt.  Only assert if the critical nesting count is 1 to
              * protect against recursive calls if the assert function also uses a
              * critical section. */
-            if( portGET_CRITICAL_NESTING_COUNT() == 1 )
+            if( portGET_CRITICAL_NESTING_COUNT() == 1U )
             {
                 portASSERT_IF_IN_ISR();
 

--- a/tasks.c
+++ b/tasks.c
@@ -280,12 +280,12 @@ typedef BaseType_t TaskRunning_t;
 /* Indicates that the task is an Idle task. */
 #define taskATTRIBUTE_IS_IDLE    ( UBaseType_t ) ( 1UL << 0UL )
 
-#if ( configNUM_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 )
+#if ( ( configNUM_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 ) )
     #define portGET_CRITICAL_NESTING_COUNT()          ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting )
     #define portSET_CRITICAL_NESTING_COUNT( x )       ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting = ( x ) )
     #define portINCREMENT_CRITICAL_NESTING_COUNT()    ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting++ )
     #define portDECREMENT_CRITICAL_NESTING_COUNT()    ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting-- )
-#endif /* #if ( configNUM_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 ) */
+#endif /* #if ( ( configNUM_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 ) ) */
 
 /*
  * Task control block.  A task control block (TCB) is allocated for each task,


### PR DESCRIPTION
Port can choose to maintain critical nesting count in port or TCB

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
