### PR TITLE
Not preempt equal priority task in the following functions

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2502,7 +2502,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                         }
                         else if( xYieldForTask != pdFALSE )
                         {
-                            prvYieldForTask( pxTCB, pdTRUE );
+                            prvYieldForTask( pxTCB, pdFALSE );
                         }
                         else
                         {
@@ -2569,7 +2569,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                          * scheduled on any of those cores. */
                         if( ( uxPrevNotAllowedCores & uxCoreAffinityMask ) != 0U )
                         {
-                            prvYieldForTask( pxTCB, pdTRUE );
+                            prvYieldForTask( pxTCB, pdFALSE );
                         }
                     }
                     #else /* #if( configUSE_PREEMPTION == 1 ) */
@@ -2935,7 +2935,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     {
                         #if ( configUSE_PREEMPTION == 1 )
                         {
-                            prvYieldForTask( pxTCB, pdTRUE );
+                            prvYieldForTask( pxTCB, pdFALSE );
                         }
                         #endif /* #if ( configUSE_PREEMPTION == 1 ) */
                     }
@@ -3028,7 +3028,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
                 #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) )
                 {
-                    prvYieldForTask( pxTCB, pdTRUE );
+                    prvYieldForTask( pxTCB, pdFALSE );
 
                     if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
                     {


### PR DESCRIPTION
* vTaskResume
* vTaskResumeFromISR
* vTaskPrioritySet
* vTaskCoreAffinitySet

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
