### PR TITLE
portYield is not called when exit critical section from ISR

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -6297,8 +6297,6 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
-        BaseType_t xYieldCurrentTask;
-
         if( xSchedulerRunning != pdFALSE )
         {
             /* If critical nesting count is zero then this function
@@ -6311,20 +6309,8 @@ static void prvResetNextTaskUnblockTime( void )
 
                 if( portGET_CRITICAL_NESTING_COUNT() == 0U )
                 {
-                    /* Get the xYieldPending stats inside the critical section. */
-                    xYieldCurrentTask = xYieldPendings[ portGET_CORE_ID() ];
-
                     portRELEASE_ISR_LOCK();
                     portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
-
-                    /* When a task yields in a critical section it just sets
-                     * xYieldPending to true. So now that we have exited the
-                     * critical section check if xYieldPending is true, and
-                     * if so yield. */
-                    if( xYieldCurrentTask != pdFALSE )
-                    {
-                        portYIELD();
-                    }
                 }
                 else
                 {


### PR DESCRIPTION
* Reference SMP branch [here](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/0f9e6e5b521009f585018b47f7e8aa573f010206/tasks.c#L5386-L5406)

```
    if( portCHECK_IF_IN_ISR() == pdFALSE )
    {
        portRELEASE_TASK_LOCK();
        portENABLE_INTERRUPTS();

        /* When a task yields in a critical section it just sets
         * xYieldPending to true. So now that we have exited the
         * critical section check if xYieldPending is true, and
         * if so yield. */
        if( xYieldPending != pdFALSE )
        {
            portYIELD();
        }
    }
    else
    {
        /* In an ISR we don't hold the task lock and don't
         * need to yield. Yield will happen if necessary when
         * the application ISR calls portEND_SWITCHING_ISR() */
        mtCOVERAGE_TEST_MARKER();
    }
```

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
