### PR TITLE
Yield for priority inherit and disinherit task

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -5817,6 +5817,16 @@ static void prvResetNextTaskUnblockTime( void )
                     /* Inherit the priority before being moved into the new list. */
                     pxMutexHolderTCB->uxPriority = pxCurrentTCB->uxPriority;
                     prvAddTaskToReadyList( pxMutexHolderTCB );
+                    #if ( configNUMBER_OF_CORES > 1 )
+                    {
+                        /* The priority of the task is raised. Yield for this task
+                         * if it is not running. */
+                        if( taskTASK_IS_RUNNING( pxMutexHolderTCB ) != pdTRUE )
+                        {
+                            prvYieldForTask( pxMutexHolderTCB );
+                        }
+                    }
+                    #endif /* if ( configNUMBER_OF_CORES > 1 ) */
                 }
                 else
                 {
@@ -5907,6 +5917,16 @@ static void prvResetNextTaskUnblockTime( void )
                      * running to give back the mutex. */
                     listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxTCB->uxPriority ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
                     prvAddTaskToReadyList( pxTCB );
+                    #if ( configNUMBER_OF_CORES > 1 )
+                    {
+                        /* The priority of the task is dropped. Yield the core on
+                         * which the task is running. */
+                        if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                        {
+                            prvYieldCore( pxTCB->xTaskRunState );
+                        }
+                    }
+                    #endif /* if ( configNUMBER_OF_CORES > 1 ) */
 
                     /* Return true to indicate that a context switch is required.
                      * This is only actually required in the corner case whereby
@@ -6020,6 +6040,16 @@ static void prvResetNextTaskUnblockTime( void )
                         }
 
                         prvAddTaskToReadyList( pxTCB );
+                        #if ( configNUMBER_OF_CORES > 1 )
+                        {
+                            /* The priority of the task is dropped. Yield the core on
+                             * which the task is running. */
+                            if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                            {
+                                prvYieldCore( pxTCB->xTaskRunState );
+                            }
+                        }
+                        #endif /* if ( configNUMBER_OF_CORES > 1 ) */
                     }
                     else
                     {


### PR DESCRIPTION
Yield for priority inherit and disinherit task

Description
-----------
* Reference the test case in this PR https://github.com/joshzarr/FreeRTOS/pull/12
* Yield for the task which priority is raised when priority inheritance.
* Yield for the task which priority is dropped when priority disinheritance.
* Yield for the task which priority is dropped when priority disinheritance timeout.

Without this patch, In the following code from GenQTest.c, there will be high priority task ( xHighPriorityMutexTask ) and low priority task running at the same time.
```
        if( xTaskAbortDelay( xHighPriorityMutexTask ) != pdPASS )
        {
            xErrorDetected = pdTRUE;
        }

        while( uxTaskPriorityGet( NULL ) != genqMUTEX_MEDIUM_PRIORITY )
        {
            /* If this task gets stuck here then the check variables will stop
             * incrementing and the check task will detect the error. */
            vTaskDelay( genqSHORT_BLOCK );
        }

        /* And finally, when the medium priority task also have its delay
         * aborted there are no other tasks waiting for the mutex so this task
         * returns to its base priority. */
        xBlockWasAborted = pdTRUE;

        if( xTaskAbortDelay( xSecondMediumPriorityMutexTask ) != pdPASS )
        {
            xErrorDetected = pdTRUE;
        }
```

In single core, the disinherited task can't be the running task cause to the core is running the higher priority task.
In SMP, it is possible that the disinherited task still running on the other core. Therefore, a yield is required for the core to ensure task priority order.

Test Steps
-----------
Running the GenQTest.c
Adding busy loop in the function can speed up the GenQTest assertion at this line [GenQTest.c](https://github.com/FreeRTOS/FreeRTOS/blob/fe9322ca23ec6c6a54a879b951352a18ebf30b30/FreeRTOS/Demo/Common/Minimal/GenQTest.c#L642).
```
static void prvHighPriorityMutexTask( void * pvParameters )
{
    SemaphoreHandle_t xMutex = ( SemaphoreHandle_t ) pvParameters;

    for( ; ; )
    {
        /* The high priority task starts by suspending itself.  The low
         * priority task will unsuspend this task when required. */
        vTaskSuspend( NULL );

        /* When this task unsuspends all it does is attempt to obtain the
         * mutex.  It should find the mutex is not available so a block time is
         * specified. */
        if( xSemaphoreTake( xMutex, portMAX_DELAY ) != pdPASS )
        {
            for( volatile int a = 0; a < 1000; a++ );  // <=== Adding busy loop here

            /* This task would expect to obtain the mutex unless its wait for
             * the mutex was aborted. */
            if( xBlockWasAborted == pdFALSE )
            {
                xGenQErrorDetected = pdTRUE;
            }
            else
            {
                xBlockWasAborted = pdFALSE;
            }
        }
        else
        {
            /* When the mutex is eventually obtained it is just given back before
             * returning to suspend ready for the next cycle. */
            if( xSemaphoreGive( xMutex ) != pdPASS )
            {
                xGenQErrorDetected = pdTRUE;
            }
        }
    }
}
```

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
