### PR TITLE
Adding portIDLE_TASK_TEST_MOCK in idle task function

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1268,8 +1268,8 @@
     #define configRUN_ADDITIONAL_TESTS    0
 #endif
 
-#ifndef portIDLE_TASK_TEST_MOCK
-    #define portIDLE_TASK_TEST_MOCK()
+#ifndef portIDLE_TASK_HOOK
+    #define portIDLE_TASK_HOOK()
 #endif
 
 /* Sometimes the FreeRTOSConfig.h settings only allow a task to be created using

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1268,8 +1268,8 @@
     #define configRUN_ADDITIONAL_TESTS    0
 #endif
 
-#ifndef portIDLE_TASK_HOOK
-    #define portIDLE_TASK_HOOK()
+#ifndef configIDLE_TASK_HOOK
+    #define configIDLE_TASK_HOOK()
 #endif
 
 /* Sometimes the FreeRTOSConfig.h settings only allow a task to be created using

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1268,6 +1268,10 @@
     #define configRUN_ADDITIONAL_TESTS    0
 #endif
 
+#ifndef portIDLE_TASK_TEST_MOCK
+    #define portIDLE_TASK_TEST_MOCK()
+#endif
+
 /* Sometimes the FreeRTOSConfig.h settings only allow a task to be created using
  * dynamically allocated RAM, in which case when any task is deleted it is known
  * that both the task's stack and TCB need to be freed.  Sometimes the

--- a/tasks.c
+++ b/tasks.c
@@ -5010,8 +5010,8 @@ void vTaskMissedYield( void )
 
             /* Code below here allows additional code to be inserted into idle task
              * function, especially for loop controlling (for example when performing
-             * unit tests) */
-            portIDLE_TASK_HOOK();
+             * unit tests). */
+            configIDLE_TASK_HOOK();
         }
     }
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
@@ -5168,8 +5168,8 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
 
         /* Code below here allows additional code to be inserted into idle task
          * function, especially for loop controlling (for example when performing
-         * unit tests) */
-        portIDLE_TASK_HOOK();
+         * unit tests). */
+        configIDLE_TASK_HOOK();
     }
 }
 /*-----------------------------------------------------------*/

--- a/tasks.c
+++ b/tasks.c
@@ -5011,7 +5011,7 @@ void vTaskMissedYield( void )
             /* Code below here allows additional code to be inserted into idle task
              * function, especially for loop controlling (for example when performing
              * unit tests) */
-            portIDLE_TASK_TEST_MOCK();
+            portIDLE_TASK_HOOK();
         }
     }
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
@@ -5169,7 +5169,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
         /* Code below here allows additional code to be inserted into idle task
          * function, especially for loop controlling (for example when performing
          * unit tests) */
-        portIDLE_TASK_TEST_MOCK();
+        portIDLE_TASK_HOOK();
     }
 }
 /*-----------------------------------------------------------*/

--- a/tasks.c
+++ b/tasks.c
@@ -5007,6 +5007,11 @@ void vTaskMissedYield( void )
                 vApplicationMinimalIdleHook();
             }
             #endif /* configUSE_MINIMAL_IDLE_HOOK */
+
+            /* Code below here allows additional code to be inserted into idle task
+             * function, especially for loop controlling (for example when performing
+             * unit tests) */
+            portIDLE_TASK_TEST_MOCK();
         }
     }
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
@@ -5160,6 +5165,11 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
             vApplicationMinimalIdleHook();
         }
         #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_MINIMAL_IDLE_HOOK == 1 ) ) */
+
+        /* Code below here allows additional code to be inserted into idle task
+         * function, especially for loop controlling (for example when performing
+         * unit tests) */
+        portIDLE_TASK_TEST_MOCK();
     }
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
* portIDLE_TASK_TEST_MOCK can be used to insert additional code in idle task. Especially for loop controlling.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
