### PR TITLE
Add INFINITE_LOOP macro to test idle task function

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1268,10 +1268,6 @@
     #define configRUN_ADDITIONAL_TESTS    0
 #endif
 
-#ifndef configIDLE_TASK_HOOK
-    #define configIDLE_TASK_HOOK()
-#endif
-
 /* Sometimes the FreeRTOSConfig.h settings only allow a task to be created using
  * dynamically allocated RAM, in which case when any task is deleted it is known
  * that both the task's stack and TCB need to be freed.  Sometimes the

--- a/tasks.c
+++ b/tasks.c
@@ -287,7 +287,7 @@ typedef BaseType_t TaskRunning_t;
     #define portDECREMENT_CRITICAL_NESTING_COUNT()    ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting-- )
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 ) ) */
 
-/* Code below here allows infinit loop controlling, especially for the infinite loop
+/* Code below here allows infinite loop controlling, especially for the infinite loop
  * in idle task function. (for example when performing unit tests). */
 #ifndef INFINITE_LOOP
     #define INFINITE_LOOP()  1

--- a/tasks.c
+++ b/tasks.c
@@ -289,8 +289,8 @@ typedef BaseType_t TaskRunning_t;
 
 /* Code below here allows infinit loop controlling, especially for the infinite loop
  * in idle task function. (for example when performing unit tests). */
-#ifndef INFINIT_LOOP
-    #define INFINIT_LOOP()  1
+#ifndef INFINITE_LOOP
+    #define INFINITE_LOOP()  1
 #endif
 
 /*
@@ -4963,7 +4963,7 @@ void vTaskMissedYield( void )
 
         taskYIELD();
 
-        while( INFINIT_LOOP() )
+        while( INFINITE_LOOP() )
         {
             #if ( configUSE_PREEMPTION == 0 )
             {
@@ -5049,7 +5049,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
     }
     #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
-    while( INFINIT_LOOP() )
+    while( INFINITE_LOOP() )
     {
         /* See if any tasks have deleted themselves - if so then the idle task
          * is responsible for freeing the deleted task's TCB and stack. */

--- a/tasks.c
+++ b/tasks.c
@@ -287,6 +287,12 @@ typedef BaseType_t TaskRunning_t;
     #define portDECREMENT_CRITICAL_NESTING_COUNT()    ( pxCurrentTCBs[ portGET_CORE_ID() ]->uxCriticalNesting-- )
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 ) ) */
 
+/* Code below here allows infinit loop controlling, especially for the infinite loop
+ * in idle task function. (for example when performing unit tests). */
+#ifndef INFINIT_LOOP
+    #define INFINIT_LOOP()  1
+#endif
+
 /*
  * Task control block.  A task control block (TCB) is allocated for each task,
  * and stores task state information, including a pointer to the task's context
@@ -4957,7 +4963,7 @@ void vTaskMissedYield( void )
 
         taskYIELD();
 
-        for( ; ; )
+        while( INFINIT_LOOP() )
         {
             #if ( configUSE_PREEMPTION == 0 )
             {
@@ -5007,11 +5013,6 @@ void vTaskMissedYield( void )
                 vApplicationMinimalIdleHook();
             }
             #endif /* configUSE_MINIMAL_IDLE_HOOK */
-
-            /* Code below here allows additional code to be inserted into idle task
-             * function, especially for loop controlling (for example when performing
-             * unit tests). */
-            configIDLE_TASK_HOOK();
         }
     }
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
@@ -5048,7 +5049,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
     }
     #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
-    for( ; ; )
+    while( INFINIT_LOOP() )
     {
         /* See if any tasks have deleted themselves - if so then the idle task
          * is responsible for freeing the deleted task's TCB and stack. */
@@ -5165,11 +5166,6 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
             vApplicationMinimalIdleHook();
         }
         #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_MINIMAL_IDLE_HOOK == 1 ) ) */
-
-        /* Code below here allows additional code to be inserted into idle task
-         * function, especially for loop controlling (for example when performing
-         * unit tests). */
-        configIDLE_TASK_HOOK();
     }
 }
 /*-----------------------------------------------------------*/

--- a/tasks.c
+++ b/tasks.c
@@ -288,7 +288,7 @@ typedef BaseType_t TaskRunning_t;
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( portCRITICAL_NESTING_IN_TCB == 1 ) ) */
 
 /* Code below here allows infinite loop controlling, especially for the infinite loop
- * in idle task function. (for example when performing unit tests). */
+ * in idle task function (for example when performing unit tests). */
 #ifndef INFINITE_LOOP
     #define INFINITE_LOOP()  1
 #endif


### PR DESCRIPTION
Add INFINITE_LOOP macro to test idle task function

Description
-----------
* Remove the configIDLE_TASK_HOOK
* Add INFINITE_LOOP macro for infinite loop controlling. Unit test can redefine this macros to run the test.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
