### PR TITLE
Remove unreachable assert in prvCheckForRunStateChange

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -741,7 +741,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                 if( uxPrevCriticalNesting == 0U )
                 {
                     /* uxPrevSchedulerSuspended must be 1. */
-                    configASSERT( uxPrevSchedulerSuspended != ( UBaseType_t ) pdFALSE );
                     portRELEASE_ISR_LOCK();
                 }
             }


### PR DESCRIPTION


<!--- Title -->

Description
-----------
* Previous assert already ensure this assert won't be triggered
```
                configASSERT( ( uxPrevCriticalNesting + uxPrevSchedulerSuspended ) == 1U );
```

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
