### PR TITLE
Remove unreachable code in preYieldForTask

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -858,7 +858,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                 }
             }
 
-            if( ( xYieldCount == 0 ) && ( taskVALID_CORE_ID( xLowestPriorityCore ) == pdTRUE ) )
+            if( ( xYieldCount == 0 ) && ( xLowestPriorityCore >= 0 ) )
             {
                 prvYieldCore( xLowestPriorityCore );
             }


### PR DESCRIPTION
* xLowestPriorityCore index can't be greater than configNUMBER_OF_CORES

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
