### PR TITLE
Fix configDEINIT_TLS_BLOCK

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -5695,7 +5695,7 @@ static void prvCheckTasksWaitingTermination( void )
         #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) || ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
         {
             /* Free up the memory allocated for the task's TLS Block. */
-            configDEINIT_TLS_BLOCK( pxCurrentTCB->xTLSBlock );
+            configDEINIT_TLS_BLOCK( pxTCB->xTLSBlock );
         }
         #endif
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

`configDEINIT_TLS_BLOCK()` currently deinitializes the the TLS block of the currently running task instead of the task to be deleted.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

- Build with `configNUMBER_OF_CORES > 1`
- Have task A and task B run on different cores
- Have task A delete task B
- Have task A access its own TLS block


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
