### PR TITLE
Fix ulTotalRunTime and ulTaskSwitchedInTime

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -4540,9 +4540,9 @@ BaseType_t xTaskIncrementTick( void )
             #if ( configGENERATE_RUN_TIME_STATS == 1 )
             {
                 #ifdef portALT_GET_RUN_TIME_COUNTER_VALUE
-                    portALT_GET_RUN_TIME_COUNTER_VALUE( ulTotalRunTime );
+                    portALT_GET_RUN_TIME_COUNTER_VALUE( ulTotalRunTime[ 0 ] );
                 #else
-                    ulTotalRunTime = ( configRUN_TIME_COUNTER_TYPE ) portGET_RUN_TIME_COUNTER_VALUE();
+                    ulTotalRunTime[ 0 ] = portGET_RUN_TIME_COUNTER_VALUE();
                 #endif
 
                 /* Add the amount of time the task has been running to the
@@ -4552,16 +4552,16 @@ BaseType_t xTaskIncrementTick( void )
                  * overflows.  The guard against negative values is to protect
                  * against suspect run time stat counter implementations - which
                  * are provided by the application, not the kernel. */
-                if( ulTotalRunTime > ulTaskSwitchedInTime )
+                if( ulTotalRunTime[ 0 ] > ulTaskSwitchedInTime[ 0 ] )
                 {
-                    pxCurrentTCB->ulRunTimeCounter += ( ulTotalRunTime - ulTaskSwitchedInTime );
+                    pxCurrentTCB->ulRunTimeCounter += ( ulTotalRunTime[ 0 ] - ulTaskSwitchedInTime[ 0 ] );
                 }
                 else
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
 
-                ulTaskSwitchedInTime = ulTotalRunTime;
+                ulTaskSwitchedInTime[ 0 ] = ulTotalRunTime[ 0 ];
             }
             #endif /* configGENERATE_RUN_TIME_STATS */
 


### PR DESCRIPTION
Description
-----------
* SMP use and array to keep ulTotalRunTime and ulTaskSwitchedInTime. Update the single core implementation.

Test Steps
-----------
* CI FreeRTOS-Kernel Demos / WIN32 MSVC should be able to be compiled without problem.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
