### PR TITLE
Set default core number to 1 in RP2040

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -86,6 +86,11 @@
     #define configUSE_MPU_WRAPPERS_V1    0
 #endif
 
+/* Set default value of configNUMBER_OF_CORES to 1 to use single core FreeRTOS. */
+#ifndef configNUMBER_OF_CORES
+    #define configNUMBER_OF_CORES    1
+#endif
+
 /* Basic FreeRTOS definitions. */
 #include "projdefs.h"
 
@@ -361,10 +366,6 @@
 
 #ifndef portSOFTWARE_BARRIER
     #define portSOFTWARE_BARRIER()
-#endif
-
-#ifndef configNUMBER_OF_CORES
-    #define configNUMBER_OF_CORES    1
 #endif
 
 #ifndef configRUN_MULTIPLE_PRIORITIES

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -115,7 +115,7 @@
 /* Multi-core */
     #define portMAX_CORE_COUNT            2
     #ifndef configNUMBER_OF_CORES
-        #define configNUMBER_OF_CORES               2
+        #define configNUMBER_OF_CORES               1
     #endif
 
     /* Check validity of number of cores specified in config */

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -114,9 +114,6 @@
 
 /* Multi-core */
     #define portMAX_CORE_COUNT            2
-    #ifndef configNUMBER_OF_CORES
-        #define configNUMBER_OF_CORES               1
-    #endif
 
     /* Check validity of number of cores specified in config */
     #if ( configNUMBER_OF_CORES < 1 || portMAX_CORE_COUNT < configNUMBER_OF_CORES )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Move default configNUMBER_OF_CORES definition forward for portmacro.h.

Test Steps
-----------
* Build FreeRTOS/FreeRTOS/Demo/ThirdParty/Community-Supported/CORTEX_M0+_RP2040.
Before : There will be compilation error.
```
Missing definition:  configUSE_MINIMAL_IDLE_HOOK must be defined in FreeRTOSConfig.h as either 1 or 0.  See the Configuration section of the FreeRTOS API documentation for details.
```
After : No compilation error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
